### PR TITLE
Jimin/my roommate info api 113

### DIFF
--- a/src/main/java/com/example/appcenter_project/controller/roommate/MyRoommateApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/MyRoommateApiSpecification.java
@@ -1,0 +1,30 @@
+package com.example.appcenter_project.controller.roommate;
+
+import com.example.appcenter_project.dto.response.roommate.ResponseMyRoommateInfoDto;
+import com.example.appcenter_project.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "MyRoommate", description = "내 룸메이트 정보 관련 API")
+public interface MyRoommateApiSpecification {
+
+    @Operation(
+            summary = "내 룸메이트 정보 조회",
+            description = "현재 로그인한 사용자의 룸메이트 정보를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseMyRoommateInfoDto.class))),
+                    @ApiResponse(responseCode = "404", description = "룸메이트 정보가 등록되지 않음 (MY_ROOMMATE_NOT_REGISTERED)",
+                            content = @Content)
+            }
+    )
+    ResponseEntity<ResponseMyRoommateInfoDto> getMyRoommate(
+            @Parameter(hidden = true) CustomUserDetails userDetails
+    );
+}

--- a/src/main/java/com/example/appcenter_project/controller/roommate/MyRoommateController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/MyRoommateController.java
@@ -1,0 +1,27 @@
+package com.example.appcenter_project.controller.roommate;
+
+import com.example.appcenter_project.dto.request.roommate.RequestRoommateFormDto;
+import com.example.appcenter_project.dto.response.roommate.ResponseMyRoommateInfoDto;
+import com.example.appcenter_project.dto.response.roommate.ResponseRoommatePostDto;
+import com.example.appcenter_project.security.CustomUserDetails;
+import com.example.appcenter_project.service.roommate.MyRoommateService;
+import com.example.appcenter_project.service.roommate.RoommateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/my-roommate")
+@RequiredArgsConstructor
+public class MyRoommateController implements MyRoommateApiSpecification {
+
+    private final MyRoommateService myRoommateService;
+    @GetMapping("/informations")
+    public ResponseEntity<ResponseMyRoommateInfoDto> getMyRoommate(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getId();
+        ResponseMyRoommateInfoDto response = myRoommateService.getMyRoommateInfo(userId);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingApiSpecification.java
@@ -48,4 +48,18 @@ public interface RoommateMatchingApiSpecification {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
+    @Operation(
+            summary = "룸메이트 매칭 거절",
+            description = "룸메이트 매칭 요청을 거절합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "매칭 거절 성공"),
+                    @ApiResponse(responseCode = "404", description = "매칭 요청을 찾을 수 없습니다. (ROOMMATE_MATCHING_NOT_FOUND)", content = @Content),
+                    @ApiResponse(responseCode = "409", description = "이미 처리된 매칭입니다. (ROOMMATE_MATCHING_ALREADY_COMPLETED)", content = @Content)
+            }
+    )
+    ResponseEntity<Void> rejectMatching(
+            @Parameter(description = "매칭 ID", example = "1") @PathVariable Long matchingId
+    );
+
+
 }

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingApiSpecification.java
@@ -33,4 +33,19 @@ public interface RoommateMatchingApiSpecification {
                     content = @Content(schema = @Schema(implementation = RequestMatchingDto.class))
             ) RequestMatchingDto requestDto
     );
+
+    @Operation(
+            summary = "룸메이트 매칭 수락",
+            description = "룸메이트 매칭 요청을 수락합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "매칭 수락 성공"),
+                    @ApiResponse(responseCode = "404", description = "매칭 요청을 찾을 수 없습니다. (ROOMMATE_MATCHING_NOT_FOUND)", content = @Content),
+                    @ApiResponse(responseCode = "409", description = "이미 처리된 매칭입니다. (ROOMMATE_MATCHING_ALREADY_COMPLETED)", content = @Content)
+            }
+    )
+    ResponseEntity<Void> acceptMatching(
+            @Parameter(description = "매칭 ID", example = "1") @PathVariable Long matchingId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
 }

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingApiSpecification.java
@@ -1,0 +1,36 @@
+package com.example.appcenter_project.controller.roommate;
+
+import com.example.appcenter_project.dto.request.roommate.RequestMatchingDto;
+import com.example.appcenter_project.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "RoommateMatching", description = "룸메이트 매칭 관련 API")
+public interface RoommateMatchingApiSpecification {
+
+    @Operation(
+            summary = "룸메이트 매칭 요청",
+            description = "상대방의 학번을 통해 룸메이트 매칭을 요청합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "매칭 요청 성공"),
+                    @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다. (ROOMMATE_USER_NOT_FOUND)", content = @Content),
+                    @ApiResponse(responseCode = "409", description = "이미 매칭 요청을 보낸 상태입니다. (ROOMMATE_MATCHING_ALREADY_REQUESTED)", content = @Content)
+            }
+    )
+    ResponseEntity<?> requestMatching(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "받는 사람의 학번 정보",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = RequestMatchingDto.class))
+            ) RequestMatchingDto requestDto
+    );
+}

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingController.java
@@ -28,6 +28,15 @@ public class RoommateMatchingController implements RoommateMatchingApiSpecificat
         ResponseRoommateMatchingDto responseDto = roommateMatchingService.requestMatching(senderId, requestDto.getReceiverStudentNumber());
         return ResponseEntity.status(201).body(responseDto);
     }
+
+    @PatchMapping("/{matchingId}/accept")
+    public ResponseEntity<Void> acceptMatching(
+            @PathVariable Long matchingId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        roommateMatchingService.acceptMatching(matchingId, userDetails.getId());
+        return ResponseEntity.ok().build();
+    }
 }
 
 

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingController.java
@@ -37,6 +37,13 @@ public class RoommateMatchingController implements RoommateMatchingApiSpecificat
         roommateMatchingService.acceptMatching(matchingId, userDetails.getId());
         return ResponseEntity.ok().build();
     }
+
+    @PatchMapping("/{matchingId}/reject")
+    public ResponseEntity<Void> rejectMatching(@PathVariable Long matchingId) {
+        roommateMatchingService.rejectMatching(matchingId);
+        return ResponseEntity.ok().build();
+    }
+
 }
 
 

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingController.java
@@ -1,0 +1,33 @@
+package com.example.appcenter_project.controller.roommate;
+
+import com.example.appcenter_project.dto.request.roommate.RequestMatchingDto;
+import com.example.appcenter_project.dto.response.roommate.ResponseRoommateMatchingDto;
+import com.example.appcenter_project.dto.response.roommate.ResponseRoommatePostDto;
+import com.example.appcenter_project.entity.user.User;
+import com.example.appcenter_project.security.CustomUserDetails;
+import com.example.appcenter_project.service.roommate.RoommateMatchingService;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/roommate-matching")
+@RequiredArgsConstructor
+public class RoommateMatchingController implements RoommateMatchingApiSpecification {
+
+    private final RoommateMatchingService roommateMatchingService;
+
+    @PostMapping("/request")
+    public ResponseEntity<ResponseRoommateMatchingDto> requestMatching(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody RequestMatchingDto requestDto
+    ) {
+        Long senderId = userDetails.getId(); // 인증된 사용자 ID
+        ResponseRoommateMatchingDto responseDto = roommateMatchingService.requestMatching(senderId, requestDto.getReceiverStudentNumber());
+        return ResponseEntity.status(201).body(responseDto);
+    }
+}
+
+

--- a/src/main/java/com/example/appcenter_project/dto/request/roommate/RequestMatchingDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/request/roommate/RequestMatchingDto.java
@@ -1,0 +1,9 @@
+// RequestMatchingDto.java
+package com.example.appcenter_project.dto.request.roommate;
+
+import lombok.Getter;
+
+@Getter
+public class RequestMatchingDto {
+    private String receiverStudentNumber;
+}

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseMyRoommateInfoDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseMyRoommateInfoDto.java
@@ -1,0 +1,15 @@
+package com.example.appcenter_project.dto.response.roommate;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResponseMyRoommateInfoDto {
+
+    private String name;         // 룸메 이름
+    private String dormType;     // 기숙사 타입
+    private String college;      // 단과대 이름
+    private String imagePath;     // 프로필 이미지 URL
+
+}

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateMatchingDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateMatchingDto.java
@@ -1,0 +1,15 @@
+package com.example.appcenter_project.dto.response.roommate;
+
+import com.example.appcenter_project.enums.roommate.MatchingStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ResponseRoommateMatchingDto {
+    private Long MatchingId;
+    private Long reciverId;
+    private MatchingStatus status;
+}

--- a/src/main/java/com/example/appcenter_project/entity/roommate/MyRoommate.java
+++ b/src/main/java/com/example/appcenter_project/entity/roommate/MyRoommate.java
@@ -1,0 +1,41 @@
+package com.example.appcenter_project.entity.roommate;
+
+import com.example.appcenter_project.converter.StringListConverter;
+import com.example.appcenter_project.entity.user.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class MyRoommate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Convert(converter = StringListConverter.class)
+    private List<String> rule;
+
+    @OneToOne
+    @JoinColumn(name = "member_id", unique = true)
+    private User user;
+
+    @OneToOne
+    @JoinColumn(name = "roommate_id", unique = true)
+    private User roommate;
+
+    @Builder
+    public MyRoommate(List<String> rule, User roommate, User user) {
+        this.rule = rule;
+        this.roommate = roommate;
+        this.user = user;
+    }
+
+
+}

--- a/src/main/java/com/example/appcenter_project/entity/roommate/RoommateMatching.java
+++ b/src/main/java/com/example/appcenter_project/entity/roommate/RoommateMatching.java
@@ -1,0 +1,46 @@
+package com.example.appcenter_project.entity.roommate;
+
+import com.example.appcenter_project.entity.user.User;
+import com.example.appcenter_project.enums.roommate.MatchingStatus;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "roommate_matching")
+public class RoommateMatching {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private MatchingStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+
+    @Builder
+    public RoommateMatching(MatchingStatus check, User sender, User receiver) {
+        this.status = check;
+        this.sender = sender;
+        this.receiver = receiver;
+    }
+
+    public void complete() {
+        this.status = MatchingStatus.COMPLETED;
+    }
+
+    public void fail() {
+        this.status = MatchingStatus.FAILED;
+    }
+}
+

--- a/src/main/java/com/example/appcenter_project/entity/user/User.java
+++ b/src/main/java/com/example/appcenter_project/entity/user/User.java
@@ -10,6 +10,7 @@ import com.example.appcenter_project.entity.like.GroupOrderLike;
 import com.example.appcenter_project.entity.like.TipLike;
 import com.example.appcenter_project.entity.roommate.RoommateBoard;
 import com.example.appcenter_project.entity.roommate.RoommateCheckList;
+import com.example.appcenter_project.entity.roommate.MyRoommate;
 import com.example.appcenter_project.entity.tip.Tip;
 import com.example.appcenter_project.enums.user.College;
 import com.example.appcenter_project.enums.user.DormType;
@@ -80,6 +81,10 @@ public class User extends BaseTimeEntity {
     @OneToOne(mappedBy = "user")
     private RoommateBoard roommateBoard;
 
+    @OneToOne(mappedBy = "user")
+    private MyRoommate myRoommate;
+
+
     @Builder
     public User(String studentNumber, String name, String password, DormType dormType, Integer penalty, Role role, Image image) {
         this.name = name;
@@ -144,5 +149,7 @@ public class User extends BaseTimeEntity {
             searchLog.remove(0); // 맨 앞 요소 제거
         }
     }
+
+
 
 }

--- a/src/main/java/com/example/appcenter_project/enums/roommate/MatchingStatus.java
+++ b/src/main/java/com/example/appcenter_project/enums/roommate/MatchingStatus.java
@@ -1,0 +1,8 @@
+package com.example.appcenter_project.enums.roommate;
+
+
+public enum MatchingStatus {
+    REQUEST,    // 요청 보낸 상태
+    COMPLETED,  // 수락된 상태
+    FAILED      // 거절된 상태
+}

--- a/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
+++ b/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
@@ -67,11 +67,14 @@ public enum ErrorCode {
     ROOMMATE_CHECKLIST_UPDATE_FAILED(BAD_REQUEST, 7008, "[Roommate] 체크리스트 수정에 실패했습니다."),
 
     // ROOMMATE_MATCHING
-    ROOMMATE_MATCHING_ALREADY_REQUESTED(CONFLICT, 7101, "[RoommateMatching] 이미 해당 사용자에게 매칭 요청을 보냈습니다."),
-    ROOMMATE_MATCHING_NOT_FOUND(NOT_FOUND, 7102, "[RoommateMatching] 해당 매칭 요청을 찾을 수 없습니다."),
-    ROOMMATE_MATCHING_ALREADY_COMPLETED(BAD_REQUEST, 7103, "[RoommateMatching] 이미 수락되었거나 실패한 요청입니다."),
-    ROOMMATE_MATCHING_NOT_FOR_USER(FORBIDDEN, 7104, "[RoommateMatching] 해당 매칭 요청은 현재 사용자와 관련이 없습니다."),
-    ROOMMATE_ALREADY_MATCHED(HttpStatus.CONFLICT,7105,"[RoommateMatching] 이미 매칭된 사람이 있습니다.");
+    ROOMMATE_MATCHING_ALREADY_REQUESTED(CONFLICT, 8101, "[RoommateMatching] 이미 해당 사용자에게 매칭 요청을 보냈습니다."),
+    ROOMMATE_MATCHING_NOT_FOUND(NOT_FOUND, 8102, "[RoommateMatching] 해당 매칭 요청을 찾을 수 없습니다."),
+    ROOMMATE_MATCHING_ALREADY_COMPLETED(BAD_REQUEST, 8103, "[RoommateMatching] 이미 수락되었거나 실패한 요청입니다."),
+    ROOMMATE_MATCHING_NOT_FOR_USER(FORBIDDEN, 8104, "[RoommateMatching] 해당 매칭 요청은 현재 사용자와 관련이 없습니다."),
+    ROOMMATE_ALREADY_MATCHED(HttpStatus.CONFLICT,8105,"[RoommateMatching] 이미 매칭된 사람이 있습니다."),
+
+    // ROOMMATE_MYROOMMATE
+    MY_ROOMMATE_NOT_REGISTERED(NOT_FOUND, 9201, "[MyRoommate] 해당 사용자의 룸메이트 정보를 찾을 수 없습니다"),;
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
+++ b/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
@@ -64,7 +64,14 @@ public enum ErrorCode {
     ROOMMATE_FORBIDDEN_ACCESS(FORBIDDEN, 7005, "[Roommate] 접근 권한이 없습니다."),
     ROOMMATE_NO_SIMILAR_BOARD(NOT_FOUND, 7006, "[Roommate] 유사도 비교할 게시글이 없습니다."),
     ROOMMATE_UPDATE_NOT_ALLOWED(FORBIDDEN, 7007, "[Roommate] 수정 권한이 없습니다."),
-    ROOMMATE_CHECKLIST_UPDATE_FAILED(BAD_REQUEST, 7008, "[Roommate] 체크리스트 수정에 실패했습니다."),;
+    ROOMMATE_CHECKLIST_UPDATE_FAILED(BAD_REQUEST, 7008, "[Roommate] 체크리스트 수정에 실패했습니다."),
+
+    // ROOMMATE_MATCHING
+    ROOMMATE_MATCHING_ALREADY_REQUESTED(CONFLICT, 7101, "[RoommateMatching] 이미 해당 사용자에게 매칭 요청을 보냈습니다."),
+    ROOMMATE_MATCHING_NOT_FOUND(NOT_FOUND, 7102, "[RoommateMatching] 해당 매칭 요청을 찾을 수 없습니다."),
+    ROOMMATE_MATCHING_ALREADY_COMPLETED(BAD_REQUEST, 7103, "[RoommateMatching] 이미 수락되었거나 실패한 요청입니다."),
+    ROOMMATE_MATCHING_NOT_FOR_USER(FORBIDDEN, 7104, "[RoommateMatching] 해당 매칭 요청은 현재 사용자와 관련이 없습니다."),
+    ROOMMATE_ALREADY_MATCHED(HttpStatus.CONFLICT,7105,"[RoommateMatching] 이미 매칭된 사람이 있습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/appcenter_project/repository/roommate/MyRoommateRepository.java
+++ b/src/main/java/com/example/appcenter_project/repository/roommate/MyRoommateRepository.java
@@ -1,0 +1,10 @@
+package com.example.appcenter_project.repository.roommate;
+
+import com.example.appcenter_project.entity.roommate.MyRoommate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MyRoommateRepository extends JpaRepository<MyRoommate, Long> {
+    Optional<MyRoommate> findByUserId(Long userId);  // userId로 내 룸메 정보 조회
+}

--- a/src/main/java/com/example/appcenter_project/repository/roommate/RoommateMatchingRepository.java
+++ b/src/main/java/com/example/appcenter_project/repository/roommate/RoommateMatchingRepository.java
@@ -1,0 +1,12 @@
+package com.example.appcenter_project.repository.roommate;
+
+
+import com.example.appcenter_project.entity.roommate.RoommateMatching;
+import com.example.appcenter_project.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoommateMatchingRepository extends JpaRepository<RoommateMatching, Long> {
+
+    boolean existsBySenderAndReceiver(User sender, User receiver);
+
+}

--- a/src/main/java/com/example/appcenter_project/service/roommate/MyRoommateService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/MyRoommateService.java
@@ -1,0 +1,35 @@
+package com.example.appcenter_project.service.roommate;
+
+import com.example.appcenter_project.dto.response.roommate.ResponseMyRoommateInfoDto;
+import com.example.appcenter_project.entity.roommate.MyRoommate;
+import com.example.appcenter_project.entity.user.User;
+import com.example.appcenter_project.exception.CustomException;
+import com.example.appcenter_project.repository.roommate.MyRoommateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.appcenter_project.exception.ErrorCode.MY_ROOMMATE_NOT_REGISTERED;
+
+@Service
+@RequiredArgsConstructor
+public class MyRoommateService {
+
+    private final MyRoommateRepository myRoommateRepository;
+
+    @Transactional(readOnly = true)
+    public ResponseMyRoommateInfoDto getMyRoommateInfo(Long userId){
+        MyRoommate myRoommate = myRoommateRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(MY_ROOMMATE_NOT_REGISTERED));
+
+        User roommate = myRoommate.getRoommate();
+
+        return ResponseMyRoommateInfoDto.builder()
+                .name(roommate.getName())
+                .dormType(roommate.getDormType() != null ? roommate.getDormType().name() : null)
+                .college(roommate.getCollege() != null ? roommate.getCollege().name() : null)
+                .imagePath(roommate.getImage() != null ? roommate.getImage().getFilePath() : null)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
@@ -81,8 +81,16 @@ public class RoommateMatchingService {
         matching.complete();
     }
 
+    // 매칭 거절
+    public void rejectMatching(Long matchingId) {
+        RoommateMatching matching = roommateMatchingRepository.findById(matchingId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_MATCHING_NOT_FOUND));
 
+        if (matching.getStatus() != MatchingStatus.REQUEST) {
+            throw new CustomException(ErrorCode.ROOMMATE_MATCHING_ALREADY_COMPLETED);
+        }
 
-
+        matching.fail();
+    }
 
 }

--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
@@ -1,11 +1,13 @@
 package com.example.appcenter_project.service.roommate;
 
 import com.example.appcenter_project.dto.response.roommate.ResponseRoommateMatchingDto;
+import com.example.appcenter_project.entity.roommate.MyRoommate;
 import com.example.appcenter_project.entity.roommate.RoommateMatching;
 import com.example.appcenter_project.entity.user.User;
 import com.example.appcenter_project.enums.roommate.MatchingStatus;
 import com.example.appcenter_project.exception.CustomException;
 import com.example.appcenter_project.exception.ErrorCode;
+import com.example.appcenter_project.repository.roommate.MyRoommateRepository;
 import com.example.appcenter_project.repository.roommate.RoommateMatchingRepository;
 import com.example.appcenter_project.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ public class RoommateMatchingService {
 
     private final RoommateMatchingRepository roommateMatchingRepository;
     private final UserRepository userRepository;
+    private final MyRoommateRepository myRoommateRepository;
 
     // 매칭 요청
     @Transactional
@@ -79,6 +82,23 @@ public class RoommateMatchingService {
         }
 
         matching.complete();
+
+        //myRoommate 저장 로직 추가
+        User sender = matching.getSender();
+        User receiver = matching.getReceiver();
+
+        MyRoommate myRoommate1 = MyRoommate.builder()
+                .user(sender)
+                .roommate(receiver)
+                .build();
+
+        MyRoommate myRoommate2 = MyRoommate.builder()
+                .user(receiver)
+                .roommate(sender)
+                .build();
+
+        myRoommateRepository.save(myRoommate1);
+        myRoommateRepository.save(myRoommate2);
     }
 
     // 매칭 거절

--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
@@ -52,4 +52,37 @@ public class RoommateMatchingService {
                 .build();
     }
 
+    // 매칭 수락
+    public void acceptMatching(Long matchingId, Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_USER_NOT_FOUND));
+
+        RoommateMatching matching = roommateMatchingRepository.findById(matchingId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_MATCHING_NOT_FOUND));
+
+
+        // 매칭 요청의 수신자가 현재 로그인한 사용자인지 확인
+        if (!matching.getReceiver().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.ROOMMATE_MATCHING_NOT_FOR_USER);
+        }
+
+
+        // 이미 완료된 요청인지 확인
+        if (matching.getStatus() != MatchingStatus.REQUEST) {
+            throw new CustomException(ErrorCode.ROOMMATE_MATCHING_ALREADY_COMPLETED);
+        }
+
+        // 이미 매칭 완료된 사람인지 확인
+        if (user.getRoommateBoard() != null) {
+            throw new CustomException(ErrorCode.ROOMMATE_ALREADY_MATCHED);
+        }
+
+        matching.complete();
+    }
+
+
+
+
+
 }

--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
@@ -1,0 +1,55 @@
+package com.example.appcenter_project.service.roommate;
+
+import com.example.appcenter_project.dto.response.roommate.ResponseRoommateMatchingDto;
+import com.example.appcenter_project.entity.roommate.RoommateMatching;
+import com.example.appcenter_project.entity.user.User;
+import com.example.appcenter_project.enums.roommate.MatchingStatus;
+import com.example.appcenter_project.exception.CustomException;
+import com.example.appcenter_project.exception.ErrorCode;
+import com.example.appcenter_project.repository.roommate.RoommateMatchingRepository;
+import com.example.appcenter_project.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RoommateMatchingService {
+
+    private final RoommateMatchingRepository roommateMatchingRepository;
+    private final UserRepository userRepository;
+
+    // 매칭 요청
+    @Transactional
+    public ResponseRoommateMatchingDto requestMatching(Long senderId, String receiverStudentNumber) {
+        User sender = userRepository.findById(senderId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_USER_NOT_FOUND));
+
+        User receiver = userRepository.findByStudentNumber(receiverStudentNumber)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_USER_NOT_FOUND));
+
+        if (receiver.getRoommateBoard() != null) {
+            throw new CustomException(ErrorCode.ROOMMATE_ALREADY_MATCHED);
+        }
+
+        boolean exists = roommateMatchingRepository.existsBySenderAndReceiver(sender, receiver);
+        if (exists) {
+            throw new CustomException(ErrorCode.ROOMMATE_MATCHING_ALREADY_REQUESTED);
+        }
+
+        RoommateMatching matching = RoommateMatching.builder()
+                .check(MatchingStatus.REQUEST)
+                .sender(sender)
+                .receiver(receiver)
+                .build();
+
+        roommateMatchingRepository.save(matching);
+
+        return ResponseRoommateMatchingDto.builder()
+                .MatchingId(matching.getId())
+                .reciverId(matching.getReceiver().getId())
+                .status(matching.getStatus())
+                .build();
+    }
+
+}


### PR DESCRIPTION
###관련 이슈
#113 

### 구현한 내용
RoommateMatchingService.acceptMatching() 내 MyRoommate 두 개 저장 로직 추가
MyRoommateService.getMyRoommateInfo()에서 roommate의 name, dormType, college, imagePath 조회
null-safe 처리 (roommate.getImage(), getCollege(), getDormType() 등)
매칭 완료 후 sender/receiver 모두 GET /my-roommate/informations로 룸메이트 정보 확인 가능하도록 구현
관련 예외 처리 (등록된 룸메이트 없을 시 404 에러 반환)

###스크린샷
<img width="1086" height="1027" alt="image" src="https://github.com/user-attachments/assets/3e957b8b-418e-47ea-9d90-3b2b3743b236" />
