### PR TITLE
Jimin/roommate similar list like count 145

### DIFF
--- a/src/main/java/com/example/appcenter_project/config/MySqlConfig.java
+++ b/src/main/java/com/example/appcenter_project/config/MySqlConfig.java
@@ -36,7 +36,7 @@ public class MySqlConfig {
     public LocalContainerEntityManagerFactoryBean entityManagerFactory(EntityManagerFactoryBuilder builder, @Qualifier("dataSource") DataSource dataSource) {
 
         Map<String, String> properties = new HashMap<String, String>();
-        properties.put("hibernate.hbm2ddl.auto", "update");
+        properties.put("hibernate.hbm2ddl.auto", "create");
 
         return builder.dataSource(dataSource).packages("com.example.appcenter_project").persistenceUnit("primary").properties(properties).build();
     }

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateApiSpecification.java
@@ -105,5 +105,35 @@ public interface RoommateApiSpecification {
             RequestRoommateFormDto requestDto
     );
 
+    @Operation(
+            summary = "룸메이트 게시글 좋아요",
+            description = "특정 게시글에 좋아요를 추가합니다. 이미 좋아요를 누른 경우 에러가 발생합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "좋아요 성공, 현재 좋아요 개수 반환",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Integer.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 유저 또는 게시글이 존재하지 않음 (ROOMMATE_USER_NOT_FOUND, ROOMMATE_BOARD_NOT_FOUND)", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "이미 좋아요를 누른 유저 (ALREADY_ROOMMATE_BOARD_LIKE_USER)", content = @Content)
+            }
+    )
+    ResponseEntity<Integer> plusLike(
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @Parameter(description = "좋아요를 누를 게시글 ID", example = "1")
+            @PathVariable Long boardId
+    );
+
+    @Operation(
+            summary = "룸메이트 게시글 좋아요 취소",
+            description = "특정 게시글의 좋아요를 취소합니다. 좋아요를 누르지 않은 경우 에러가 발생합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "좋아요 취소 성공, 현재 좋아요 개수 반환",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Integer.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 유저, 게시글 또는 좋아요 정보가 없음 (ROOMMATE_USER_NOT_FOUND, ROOMMATE_BOARD_NOT_FOUND, ROOMMATE_BOARD_LIKE_NOT_FOUND)", content = @Content)
+            }
+    )
+    ResponseEntity<Integer> minusLike(
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @Parameter(description = "좋아요 취소할 게시글 ID", example = "1")
+            @PathVariable Long boardId
+    );
 
 }

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateController.java
@@ -57,4 +57,23 @@ public class RoommateController implements RoommateApiSpecification{
         ResponseRoommatePostDto updated = roommateService.updateRoommateChecklistAndBoard(requestDto, userId);
         return ResponseEntity.ok(updated);
     }
+
+    @PostMapping("/{boardId}/like")
+    public ResponseEntity<Integer> plusLike(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long boardId
+    ) {
+        Integer likeCount = roommateService.likePlusRoommateBoard(userDetails.getId(), boardId);
+        return ResponseEntity.ok(likeCount);
+    }
+
+    @DeleteMapping("/{boardId}/like")
+    public ResponseEntity<Integer> minusLike(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long boardId
+    ) {
+        Integer likeCount = roommateService.likeMinusRoommateBoard(userDetails.getId(), boardId);
+        return ResponseEntity.ok(likeCount);
+    }
+
 }

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingApiSpecification.java
@@ -1,6 +1,8 @@
 package com.example.appcenter_project.controller.roommate;
 
 import com.example.appcenter_project.dto.request.roommate.RequestMatchingDto;
+import com.example.appcenter_project.dto.response.roommate.ResponseReceivedRoommateMatchingDto;
+import com.example.appcenter_project.dto.response.roommate.ResponseRoommateMatchingDto;
 import com.example.appcenter_project.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -60,6 +62,30 @@ public interface RoommateMatchingApiSpecification {
     ResponseEntity<Void> rejectMatching(
             @Parameter(description = "매칭 ID", example = "1") @PathVariable Long matchingId
     );
+
+    @Operation(
+            summary = "나에게 온 룸메이트 매칭 요청 리스트 조회",
+            description = "나에게 요청된 모든 룸메이트 매칭 요청(수락 대기 상태) 리스트를 조회합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "매칭 요청 리스트 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseReceivedRoommateMatchingDto.class) // ← 여기!
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "사용자를 찾을 수 없습니다. (ROOMMATE_USER_NOT_FOUND)",
+                            content = @Content
+                    )
+            }
+    )
+    ResponseEntity<?> getReceivedMatchings(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
 
 
 }

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingController.java
@@ -1,6 +1,7 @@
 package com.example.appcenter_project.controller.roommate;
 
 import com.example.appcenter_project.dto.request.roommate.RequestMatchingDto;
+import com.example.appcenter_project.dto.response.roommate.ResponseReceivedRoommateMatchingDto;
 import com.example.appcenter_project.dto.response.roommate.ResponseRoommateMatchingDto;
 import com.example.appcenter_project.dto.response.roommate.ResponseRoommatePostDto;
 import com.example.appcenter_project.entity.user.User;
@@ -11,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/roommate-matching")
@@ -43,6 +46,18 @@ public class RoommateMatchingController implements RoommateMatchingApiSpecificat
         roommateMatchingService.rejectMatching(matchingId);
         return ResponseEntity.ok().build();
     }
+
+    @GetMapping("/received")
+    public ResponseEntity<List<ResponseReceivedRoommateMatchingDto>> getReceivedMatchings(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long receiverId = userDetails.getId();
+        List<ResponseReceivedRoommateMatchingDto> responseDtos = roommateMatchingService.getReceivedMatchings(receiverId);
+        return ResponseEntity.ok(responseDtos);
+    }
+
+
+
 
 }
 

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseReceivedRoommateMatchingDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseReceivedRoommateMatchingDto.java
@@ -1,0 +1,21 @@
+package com.example.appcenter_project.dto.response.roommate;
+
+import com.example.appcenter_project.enums.roommate.MatchingStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ResponseReceivedRoommateMatchingDto {
+    private Long matchingId;
+    private Long senderId;
+    private String senderName;
+    private MatchingStatus status;
+
+    @Builder
+    public ResponseReceivedRoommateMatchingDto(Long matchingId, Long senderId, String senderName, MatchingStatus status) {
+        this.matchingId = matchingId;
+        this.senderId = senderId;
+        this.senderName = senderName;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommatePostDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommatePostDto.java
@@ -30,6 +30,7 @@ public class ResponseRoommatePostDto {
     private BedTimeType bedTime;
     private CleanlinessType arrangement;
     private String comment;
+    private int roommateBoardLike;
 
     public static ResponseRoommatePostDto entityToDto(RoommateBoard board) {
         RoommateCheckList cl = board.getRoommateCheckList();
@@ -50,6 +51,7 @@ public class ResponseRoommatePostDto {
                 .bedTime(cl.getBedTime())
                 .arrangement(cl.getArrangement())
                 .comment(cl.getComment())
+                .roommateBoardLike(board.getRoommateBoardLike())
                 .build();
     }
 }

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateSimilarityDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateSimilarityDto.java
@@ -26,5 +26,6 @@ public class ResponseRoommateSimilarityDto {
     private CleanlinessType arrangement;
     private String comment;
 
+    private int roommateBoardLike;
     private Integer similarityPercentage;
 }

--- a/src/main/java/com/example/appcenter_project/entity/groupOrder/GroupOrder.java
+++ b/src/main/java/com/example/appcenter_project/entity/groupOrder/GroupOrder.java
@@ -53,6 +53,9 @@ public class GroupOrder extends BaseTimeEntity {
     @Column(nullable = false)
     private int groupOrderLike = 0;
 
+    @Column(nullable = false)
+    private int groupOrderViewCount = 0;
+
     @Column(nullable = false, length = 100)
     private String description;
 
@@ -74,7 +77,8 @@ public class GroupOrder extends BaseTimeEntity {
     private List<GroupOrderComment> groupOrderCommentList = new ArrayList<>();
 
     @Builder
-    public GroupOrder(String title, GroupOrderType groupOrderType, Integer price, String link, int currentPeople, int maxPeople, LocalDateTime deadline, int groupOrderLike, String description, User user, GroupOrderChatRoom groupOrderChatRoom) {        this.title = title;
+    public GroupOrder(String title, GroupOrderType groupOrderType, Integer price, String link, int currentPeople, int maxPeople, LocalDateTime deadline, int groupOrderLike, String description, User user, GroupOrderChatRoom groupOrderChatRoom, int groupOrderViewCount) {
+        this.title = title;
         this.groupOrderType = groupOrderType;
         this.price = price;
         this.link = link;
@@ -82,6 +86,7 @@ public class GroupOrder extends BaseTimeEntity {
         this.maxPeople = maxPeople;
         this.deadline = deadline;
         this.groupOrderLike = groupOrderLike;
+        this.groupOrderViewCount = groupOrderViewCount;
         this.description = description;
         this.user = user;
         this.groupOrderChatRoom = groupOrderChatRoom;
@@ -111,5 +116,9 @@ public class GroupOrder extends BaseTimeEntity {
 
     public Integer minusLike() {
         return this.groupOrderLike -= 1;
+    }
+
+    public void plusViewCount() {
+        this.groupOrderViewCount += 1;
     }
 }

--- a/src/main/java/com/example/appcenter_project/entity/like/RoommateBoardLike.java
+++ b/src/main/java/com/example/appcenter_project/entity/like/RoommateBoardLike.java
@@ -1,0 +1,34 @@
+package com.example.appcenter_project.entity.like;
+
+import com.example.appcenter_project.entity.BaseTimeEntity;
+import com.example.appcenter_project.entity.roommate.RoommateBoard;
+import com.example.appcenter_project.entity.user.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class RoommateBoardLike extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // 좋아요 누른 룸메이트 게시글
+    @ManyToOne
+    @JoinColumn(name = "roommate_board_id")
+    private RoommateBoard roommateBoard;
+
+    @Builder
+    public RoommateBoardLike(User user, RoommateBoard roommateBoard) {
+        this.user = user;
+        this.roommateBoard = roommateBoard;
+    }
+}

--- a/src/main/java/com/example/appcenter_project/entity/roommate/RoommateBoard.java
+++ b/src/main/java/com/example/appcenter_project/entity/roommate/RoommateBoard.java
@@ -1,6 +1,7 @@
 package com.example.appcenter_project.entity.roommate;
 
 import com.example.appcenter_project.entity.BaseTimeEntity;
+import com.example.appcenter_project.entity.like.RoommateBoardLike;
 import com.example.appcenter_project.entity.user.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -9,6 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.lang.reflect.Member;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -29,7 +32,12 @@ public class RoommateBoard extends BaseTimeEntity {
     @JoinColumn(name = "roommate_checklist_id")
     private RoommateCheckList roommateCheckList;
 
-    private int roommateBoardLike;
+    @OneToMany(mappedBy = "roommateBoard", orphanRemoval = true, fetch = FetchType.EAGER)
+    private List<RoommateBoardLike> roommateBoardLikeList = new ArrayList<>();
+
+    @Column(nullable = false)
+    private int roommateBoardLike = 0;
+
 
     public Integer plusLike(){
         this.roommateBoardLike +=1;
@@ -52,5 +60,6 @@ public class RoommateBoard extends BaseTimeEntity {
     public void updateTitle(String title){
         this.title = title;
     }
+
 
 }

--- a/src/main/java/com/example/appcenter_project/entity/user/User.java
+++ b/src/main/java/com/example/appcenter_project/entity/user/User.java
@@ -7,6 +7,7 @@ import com.example.appcenter_project.entity.Image;
 import com.example.appcenter_project.entity.groupOrder.GroupOrder;
 import com.example.appcenter_project.entity.groupOrder.UserGroupOrderChatRoom;
 import com.example.appcenter_project.entity.like.GroupOrderLike;
+import com.example.appcenter_project.entity.like.RoommateBoardLike;
 import com.example.appcenter_project.entity.like.TipLike;
 import com.example.appcenter_project.entity.roommate.RoommateBoard;
 import com.example.appcenter_project.entity.roommate.RoommateCheckList;
@@ -134,6 +135,18 @@ public class User extends BaseTimeEntity {
     public void removeGroupOrderLike(GroupOrderLike groupOrderLike) {
         this.groupOrderLikeList.remove(groupOrderLike);
     }
+
+    @OneToMany(mappedBy = "user")
+    private List<RoommateBoardLike> roommateBoardLikeList = new ArrayList<>();
+
+    public void addRoommateBoardLike(RoommateBoardLike roommateBoardLike) {
+        this.roommateBoardLikeList.add(roommateBoardLike);
+    }
+
+    public void removeRoommateBoardLike(RoommateBoardLike roommateBoardLike) {
+        this.roommateBoardLikeList.remove(roommateBoardLike);
+    }
+
 
     public void addSearchKeyword(String keyword) {
         if (searchLog == null) {

--- a/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
+++ b/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
@@ -66,6 +66,10 @@ public enum ErrorCode {
     ROOMMATE_UPDATE_NOT_ALLOWED(FORBIDDEN, 7007, "[Roommate] 수정 권한이 없습니다."),
     ROOMMATE_CHECKLIST_UPDATE_FAILED(BAD_REQUEST, 7008, "[Roommate] 체크리스트 수정에 실패했습니다."),
 
+    // ROOMMATE_BOARD_LIKE
+    ROOMMATE_BOARD_LIKE_NOT_FOUND(NOT_FOUND, 7501, "[RoommateBoard] 좋아요 정보를 찾을 수 없습니다."),
+    ALREADY_ROOMMATE_BOARD_LIKE_USER(UNAUTHORIZED, 7502, "[RoommateBoard] 이미 해당 게시글에 좋아요를 누른 유저입니다."),
+
     // ROOMMATE_MATCHING
     ROOMMATE_MATCHING_ALREADY_REQUESTED(CONFLICT, 8101, "[RoommateMatching] 이미 해당 사용자에게 매칭 요청을 보냈습니다."),
     ROOMMATE_MATCHING_NOT_FOUND(NOT_FOUND, 8102, "[RoommateMatching] 해당 매칭 요청을 찾을 수 없습니다."),

--- a/src/main/java/com/example/appcenter_project/mapper/GroupOrderMapper.java
+++ b/src/main/java/com/example/appcenter_project/mapper/GroupOrderMapper.java
@@ -22,5 +22,5 @@ public interface GroupOrderMapper {
     List<ResponseGroupOrderDto> findGroupOrdersByUserId(@Param("userId") Long userId);
     List<GroupOrder> findAllGroupOrdersWithDetails();
 
-    void plusViewCount(@Param("id") Long groupOrderId);
+    void plusViewCount(@Param("id") Long groupOrderId, @Param("count") int count);
 }

--- a/src/main/java/com/example/appcenter_project/mapper/GroupOrderMapper.java
+++ b/src/main/java/com/example/appcenter_project/mapper/GroupOrderMapper.java
@@ -21,4 +21,6 @@ public interface GroupOrderMapper {
     List<ResponseGroupOrderDto> findLikeGroupOrders(@Param("userId") Long userId);
     List<ResponseGroupOrderDto> findGroupOrdersByUserId(@Param("userId") Long userId);
     List<GroupOrder> findAllGroupOrdersWithDetails();
+
+    void plusViewCount(@Param("id") Long groupOrderId);
 }

--- a/src/main/java/com/example/appcenter_project/repository/like/RoommateBoardLikeRepository.java
+++ b/src/main/java/com/example/appcenter_project/repository/like/RoommateBoardLikeRepository.java
@@ -1,0 +1,13 @@
+package com.example.appcenter_project.repository.like;
+
+import com.example.appcenter_project.entity.like.RoommateBoardLike;
+import com.example.appcenter_project.entity.roommate.RoommateBoard;
+import com.example.appcenter_project.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoommateBoardLikeRepository extends JpaRepository<RoommateBoardLike, Long> {
+    boolean existsByUserAndRoommateBoard(User user, RoommateBoard roommateBoard);
+    Optional<RoommateBoardLike> findByUserAndRoommateBoard(User user, RoommateBoard roommateBoard);
+}

--- a/src/main/java/com/example/appcenter_project/repository/roommate/RoommateMatchingRepository.java
+++ b/src/main/java/com/example/appcenter_project/repository/roommate/RoommateMatchingRepository.java
@@ -3,10 +3,17 @@ package com.example.appcenter_project.repository.roommate;
 
 import com.example.appcenter_project.entity.roommate.RoommateMatching;
 import com.example.appcenter_project.entity.user.User;
+import com.example.appcenter_project.enums.roommate.MatchingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface RoommateMatchingRepository extends JpaRepository<RoommateMatching, Long> {
 
     boolean existsBySenderAndReceiver(User sender, User receiver);
+    List<RoommateMatching> findAllByReceiverAndStatus(User receiver, MatchingStatus status);
+    boolean existsBySenderAndStatus(User sender, MatchingStatus status);
+    boolean existsByReceiverAndStatus(User receiver, MatchingStatus status);
+
 
 }

--- a/src/main/java/com/example/appcenter_project/service/groupOrder/GroupOrderLockFacade.java
+++ b/src/main/java/com/example/appcenter_project/service/groupOrder/GroupOrderLockFacade.java
@@ -1,18 +1,28 @@
 package com.example.appcenter_project.service.groupOrder;
 
 import com.example.appcenter_project.mapper.GroupOrderMapper;
+import com.example.appcenter_project.utils.MealTimeChecker;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GroupOrderLockFacade {
+
     private final GroupOrderMapper groupOrderMapper;
     private final RedissonClient redissonClient;
+    private final RedisTemplate redisTemplate;
 
     public void plusGroupOrderViewCount(Long groupOrderId) {
         // 락 획득
@@ -24,11 +34,61 @@ public class GroupOrderLockFacade {
                 throw new IllegalArgumentException();
             }
             // 게시글 조회 & 조회수 +1
-            groupOrderMapper.plusViewCount(groupOrderId);
+            groupOrderMapper.plusViewCount(groupOrderId, 1);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }finally {
             lock.unlock();
+        }
+    }
+
+    public void plusGroupOrderScheduledViewCount(Long groupOrderId) {
+        String key = "group_order_view:" + groupOrderId.toString();
+
+        log.info("redis에 저장 : " + key);
+
+        if (!redisTemplate.hasKey(key)) {
+            redisTemplate.opsForValue().set(key, 1);
+        } else {
+            redisTemplate.opsForValue().increment(key);
+        }
+    }
+
+    /**
+     * 식사시간마다 redis에서 mysql로 조회수 증가
+     */
+    @Scheduled(cron = "0 * 12-14,18-23 * * *")
+    @Transactional
+    public void combineGroupOrderViewCount() {
+        // Redis에서 group_order_view: 패턴의 모든 키 조회
+        Set<String> keys = redisTemplate.keys("group_order_view:*");
+
+        if (keys == null || keys.isEmpty()) {
+            return;
+        }
+
+        for (String key : keys) {
+            try {
+                // 키에서 groupOrderId 추출
+                String groupOrderIdStr = key.replace("group_order_view:", "");
+                Long groupOrderId = Long.valueOf(groupOrderIdStr);
+
+                // Redis에서 조회수 값 가져오기
+                Object viewCountObj = redisTemplate.opsForValue().get(key);
+                if (viewCountObj != null) {
+                    Integer viewCount = Integer.valueOf(viewCountObj.toString());
+
+                    // MySQL에 조회수 업데이트 (viewCount만큼 증가)
+                    groupOrderMapper.plusViewCount(groupOrderId, viewCount);
+                    log.info("redis에서 mysql로 증가 groupOrderId : {} viewCount : {}", groupOrderId, viewCount);
+                    // Redis에서 해당 키 삭제 (동기화 완료)
+                    redisTemplate.delete(key);
+                }
+            } catch (NumberFormatException e) {
+                log.warn("Invalid key format: {}", key);
+            } catch (Exception e) {
+                log.error("Error processing key: {}, error: {}", key, e.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/example/appcenter_project/service/groupOrder/GroupOrderLockFacade.java
+++ b/src/main/java/com/example/appcenter_project/service/groupOrder/GroupOrderLockFacade.java
@@ -1,0 +1,34 @@
+package com.example.appcenter_project.service.groupOrder;
+
+import com.example.appcenter_project.mapper.GroupOrderMapper;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class GroupOrderLockFacade {
+    private final GroupOrderMapper groupOrderMapper;
+    private final RedissonClient redissonClient;
+
+    public void plusGroupOrderViewCount(Long groupOrderId) {
+        // 락 획득
+        RLock lock = redissonClient.getLock(String.format("group_order:click:%d", groupOrderId));
+        try {
+            // 락 획득에 성공하면
+            boolean available = lock.tryLock(10, 1, TimeUnit.SECONDS);
+            if (!available) {
+                throw new IllegalArgumentException();
+            }
+            // 게시글 조회 & 조회수 +1
+            groupOrderMapper.plusViewCount(groupOrderId);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }finally {
+            lock.unlock();
+        }
+    }
+}

--- a/src/main/java/com/example/appcenter_project/service/groupOrder/GroupOrderService.java
+++ b/src/main/java/com/example/appcenter_project/service/groupOrder/GroupOrderService.java
@@ -114,9 +114,14 @@ public class GroupOrderService {
 
         // GroupOrder 조회수 증가
         if (MealTimeChecker.isDinnerTime() || MealTimeChecker.isLunchTime()){
-            groupOrderLockFacade.plusGroupOrderViewCount(groupOrderId);
+            // Redisson 분산락 활용 조회수 증가
+            //groupOrderLockFacade.plusGroupOrderViewCount(groupOrderId);
+
+            // Redis 스케줄링 조회수 증가
+            groupOrderLockFacade.plusGroupOrderScheduledViewCount(groupOrderId);
+
         } else {
-            groupOrderMapper.plusViewCount(groupOrderId);
+            groupOrderMapper.plusViewCount(groupOrderId, 1);
         }
 
         return buildHierarchicalComments(dto, false);

--- a/src/main/java/com/example/appcenter_project/service/groupOrder/GroupOrderService.java
+++ b/src/main/java/com/example/appcenter_project/service/groupOrder/GroupOrderService.java
@@ -24,6 +24,7 @@ import com.example.appcenter_project.repository.groupOrder.UserGroupOrderChatRoo
 import com.example.appcenter_project.repository.image.ImageRepository;
 import com.example.appcenter_project.repository.like.GroupOrderLikeRepository;
 import com.example.appcenter_project.repository.user.UserRepository;
+import com.example.appcenter_project.utils.MealTimeChecker;
 import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -59,6 +60,7 @@ public class GroupOrderService {
     private final ImageRepository imageRepository;
     private final GroupOrderMapper groupOrderMapper;
     private final DeliveryCacheService deliveryCacheService;
+    private final GroupOrderLockFacade groupOrderLockFacade;
 
     public void saveGroupOrder(Long userId, RequestGroupOrderDto requestGroupOrderDto) {
         // GroupOrder 저장
@@ -110,7 +112,12 @@ public class GroupOrderService {
             throw new CustomException(GROUP_ORDER_NOT_FOUND);
         }
 
-        groupOrderMapper.plusViewCount(groupOrderId);
+        // GroupOrder 조회수 증가
+        if (MealTimeChecker.isDinnerTime() || MealTimeChecker.isLunchTime()){
+            groupOrderLockFacade.plusGroupOrderViewCount(groupOrderId);
+        } else {
+            groupOrderMapper.plusViewCount(groupOrderId);
+        }
 
         return buildHierarchicalComments(dto, false);
     }

--- a/src/main/java/com/example/appcenter_project/service/groupOrder/GroupOrderService.java
+++ b/src/main/java/com/example/appcenter_project/service/groupOrder/GroupOrderService.java
@@ -110,6 +110,8 @@ public class GroupOrderService {
             throw new CustomException(GROUP_ORDER_NOT_FOUND);
         }
 
+        groupOrderMapper.plusViewCount(groupOrderId);
+
         return buildHierarchicalComments(dto, false);
     }
 

--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateService.java
@@ -192,6 +192,7 @@ public class RoommateService {
                             .arrangement(cl.getArrangement())
                             .comment(cl.getComment())
                             .similarityPercentage(entry.getValue())
+                            .roommateBoardLike(entry.getKey().getRoommateBoardLike())
                             .build();
                 })
                 .toList();

--- a/src/main/java/com/example/appcenter_project/utils/MealTimeChecker.java
+++ b/src/main/java/com/example/appcenter_project/utils/MealTimeChecker.java
@@ -25,19 +25,19 @@ public class MealTimeChecker {
         return isLunchTime(currentHour) || isDinnerTime(currentHour);
     }
 
-    public boolean isLunchTime() {
+    public static boolean isLunchTime() {
         return isLunchTime(LocalTime.now().getHour());
     }
 
-    public boolean isDinnerTime() {
+    public static boolean isDinnerTime() {
         return isDinnerTime(LocalTime.now().getHour());
     }
 
-    private boolean isLunchTime(int hour) {
+    private static boolean isLunchTime(int hour) {
         return hour >= LUNCH_START_HOUR && hour < LUNCH_END_HOUR;
     }
 
-    private boolean isDinnerTime(int hour) {
+    private static boolean isDinnerTime(int hour) {
         return hour >= DINNER_START_HOUR && hour < DINNER_END_HOUR;
     }
 

--- a/src/main/resources/mapper/GroupOrderMapper.xml
+++ b/src/main/resources/mapper/GroupOrderMapper.xml
@@ -472,7 +472,7 @@
     <!-- GroupOrder 조회수 증가 메서드 -->
     <select id="plusViewCount">
         UPDATE group_order go
-        SET go.group_order_view_count = go.group_order_view_count + 1
+        SET go.group_order_view_count = go.group_order_view_count + #{count}
         WHERE go.id = #{id}
     </select>
 </mapper>

--- a/src/main/resources/mapper/GroupOrderMapper.xml
+++ b/src/main/resources/mapper/GroupOrderMapper.xml
@@ -469,4 +469,10 @@
         WHERE go.id = #{id}
     </select>
 
+    <!-- GroupOrder 조회수 증가 메서드 -->
+    <select id="plusViewCount">
+        UPDATE group_order go
+        SET go.group_order_view_count = go.group_order_view_count + 1
+        WHERE go.id = #{id}
+    </select>
 </mapper>


### PR DESCRIPTION
### 관련 이슈
#145 

### 구현한 기능
- 유사한 룸메이트 게시글 리스트(`/roommates/similar`) 응답에서 각 게시글의 좋아요 개수(roommateBoardLike)를 반환하도록 기능을 추가했습니다.
- `ResponseRoommateSimilarityDto`에 `roommateBoardLike` 필드를 추가하고, 서비스 레이어에서 해당 값이 포함되도록 매핑 로직을 수정했습니다.
- 프론트엔드에서 유사 게시글 리스트에 좋아요 수를 바로 표시할 수 있습니다.

