### PR TITLE
feat: 힌두교, 유대교 추가 #179

### DIFF
--- a/src/main/java/com/example/appcenter_project/enums/roommate/ReligionType.java
+++ b/src/main/java/com/example/appcenter_project/enums/roommate/ReligionType.java
@@ -12,6 +12,8 @@ public enum ReligionType {
     BUDDHIST("불교"),
     CATHOLIC("천주교"),
     ISLAM("이슬람교"),
+    HINDU("힌두교"),
+    JEWISH("유대교"),
     NONE("무교"),
     OTHER("기타");
 


### PR DESCRIPTION
### 관련이슈
#179

### 구현한 기능
- 기존 ReligionType enum에 HINDU(힌두교), JEWISH(유대교) 항목을 추가했습니다.
- 이제 "힌두교", "유대교"도 선택 및 저장할 수 있습니다.
- @JsonCreator/@JsonValue 로직도 그대로 적용되어 한글/영문 모두 매핑 가능합니다.