### PR TITLE
Jimin/allow host leave chatroom 185

### DIFF
--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateChattingRoomService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateChattingRoomService.java
@@ -86,17 +86,17 @@ public class RoommateChattingRoomService {
 
     //채팅방 나가기
     @Transactional
-    public void leaveChatRoom(Long guestId, Long chatRoomId) {
+    public void leaveChatRoom(Long userId, Long chatRoomId) {
         // 유저 조회
-        User guest = userRepository.findById(guestId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         // 채팅방 조회
         RoommateChattingRoom chatRoom = roommateChattingRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new CustomException(ROOMMATE_CHAT_ROOM_NOT_FOUND));
 
-        // 채팅방의 게스트와 일치하는지 확인
-        if (!chatRoom.getGuest().getId().equals(guest.getId())) {
+        // 채팅방에 속한 두 명(호스트 또는 게스트)만 나가기 가능
+        if (!chatRoom.getGuest().getId().equals(user.getId()) && !chatRoom.getHost().getId().equals(user.getId())) {
             throw new CustomException(ROOMMATE_FORBIDDEN_ACCESS);
         }
 


### PR DESCRIPTION
### 관련 이슈
#185 

### 구현한 내용
- 기존에는 게스트만 채팅방을 나갈 수 있었으나, 이제 호스트(게시글 작성자)도 나갈 수 있도록 허용했습니다.
- 호스트 또는 게스트가 나가면 채팅방 전체가 삭제되도록 동작을 수정했습니다.
- 호스트나 게스트가 아닌 사용자가 나가기를 시도할 경우 권한 예외를 반환합니다.

### 스크린샷
<img width="1310" height="1047" alt="image" src="https://github.com/user-attachments/assets/f97ac9a2-e4e6-4db9-8529-d07c77beeab0" />
