### PR TITLE
Jimin/roommate matching cancel 187

### DIFF
--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingApiSpecification.java
@@ -86,6 +86,19 @@ public interface RoommateMatchingApiSpecification {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
-
+    @Operation(
+            summary = "룸메이트 매칭 취소",
+            description = "내가 요청한 룸메이트 매칭을 취소(삭제)합니다. (매칭 완료 상태일 때만 가능)",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "매칭 취소 성공"),
+                    @ApiResponse(responseCode = "404", description = "매칭 요청을 찾을 수 없습니다. (ROOMMATE_MATCHING_NOT_FOUND)", content = @Content),
+                    @ApiResponse(responseCode = "400", description = "매칭이 완료된 상태가 아닙니다. (ROOMMATE_MATCHING_NOT_COMPLETED)", content = @Content),
+                    @ApiResponse(responseCode = "403", description = "본인이 요청한 매칭이 아닙니다. (ROOMMATE_MATCHING_NOT_FOR_USER)", content = @Content)
+            }
+    )
+    ResponseEntity<Void> cancelMatching(
+            @Parameter(description = "매칭 ID", example = "1") @PathVariable Long matchingId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
 
 }

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingController.java
@@ -56,7 +56,14 @@ public class RoommateMatchingController implements RoommateMatchingApiSpecificat
         return ResponseEntity.ok(responseDtos);
     }
 
-
+    @PatchMapping("/{matchingId}/cancel")
+    public ResponseEntity<Void> cancelMatching(
+            @PathVariable Long matchingId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        roommateMatchingService.cancelMatching(matchingId, userDetails.getId());
+        return ResponseEntity.ok().build();
+    }
 
 
 }

--- a/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
+++ b/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
@@ -76,6 +76,8 @@ public enum ErrorCode {
     ROOMMATE_MATCHING_ALREADY_COMPLETED(BAD_REQUEST, 8103, "[RoommateMatching] 이미 수락되었거나 실패한 요청입니다."),
     ROOMMATE_MATCHING_NOT_FOR_USER(FORBIDDEN, 8104, "[RoommateMatching] 해당 매칭 요청은 현재 사용자와 관련이 없습니다."),
     ROOMMATE_ALREADY_MATCHED(HttpStatus.CONFLICT,8105,"[RoommateMatching] 이미 매칭된 사람이 있습니다."),
+    ROOMMATE_MATCHING_NOT_COMPLETED(BAD_REQUEST, 8106, "[RoommateMatching] 매칭이 완료된 상태가 아닙니다."),
+
 
     // ROOMMATE_MYROOMMATE
     MY_ROOMMATE_NOT_REGISTERED(NOT_FOUND, 9201, "[MyRoommate] 해당 사용자의 룸메이트 정보를 찾을 수 없습니다"),

--- a/src/main/java/com/example/appcenter_project/repository/roommate/MyRoommateRepository.java
+++ b/src/main/java/com/example/appcenter_project/repository/roommate/MyRoommateRepository.java
@@ -1,10 +1,13 @@
 package com.example.appcenter_project.repository.roommate;
 
 import com.example.appcenter_project.entity.roommate.MyRoommate;
+import com.example.appcenter_project.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface MyRoommateRepository extends JpaRepository<MyRoommate, Long> {
     Optional<MyRoommate> findByUserId(Long userId);  // userId로 내 룸메 정보 조회
+    void deleteByUserAndRoommate(User user, User roommate);
+
 }


### PR DESCRIPTION
### 관련 이슈
#187 

### 구현한 내용
- 매칭이 완료(COMPLETED)된 상태의 룸메이트 매칭을 끊을 수 있는 API를 추가했습니다.
- 본인이 해당 매칭의 sender 또는 receiver일 때만 취소가 가능합니다.
- 매칭 끊기 시, 관련된 MyRoommate 양방향 데이터도 함께 삭제되도록 처리하였습니다.
- 서비스, 컨트롤러, 스웨거 명세, 에러 코드 등을 추가 및 수정하였습니다.

### 스크린샷
<img width="1178" height="805" alt="image" src="https://github.com/user-attachments/assets/ed20d1e3-1843-4ecc-b4cf-933a226052da" />
