### PR TITLE
fix: 내 룸메이트 체크리스트 조회 시 종교 정보(religion) 필드 누락 수정 #193

### DIFF
--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateCheckListDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateCheckListDto.java
@@ -17,6 +17,7 @@ public class ResponseRoommateCheckListDto {
     private Set<DormDay> dormPeriod;
     private DormType dormType;
     private College college;
+    private ReligionType religion;
     private String mbti;
     private SmokingType smoking;
     private SnoringType snoring;
@@ -34,6 +35,7 @@ public class ResponseRoommateCheckListDto {
                 .dormPeriod(checklist.getDormPeriod())
                 .dormType(checklist.getDormType())
                 .college(checklist.getCollege())
+                .religion(checklist.getReligion())
                 .mbti(checklist.getMbti())
                 .smoking(checklist.getSmoking())
                 .snoring(checklist.getSnoring())


### PR DESCRIPTION
### 관련 이슈
#193 

### 구현한 내용
- 내 룸메이트 체크리스트 조회 API(ResponseRoommateCheckListDto)에 종교(religion) 필드 추가
- from(RoommateCheckList) 메서드에서 religion 값도 함께 빌드되도록 수정
- RoommateCheckList 엔티티의 religion 값을 그대로 반환하도록 반영

### 관련 사진
<img width="1327" height="1246" alt="image" src="https://github.com/user-attachments/assets/1025b756-6e0b-4895-bb51-a8fad80ed4bd" />
