### PR TITLE
Jimin/include matching id in my roommate info 197

### DIFF
--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseMyRoommateInfoDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseMyRoommateInfoDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Builder
 public class ResponseMyRoommateInfoDto {
 
+    private Long matchingId;     // 매칭 ID
     private String name;         // 룸메 이름
     private String dormType;     // 기숙사 타입
     private String college;      // 단과대 이름

--- a/src/main/java/com/example/appcenter_project/repository/roommate/RoommateMatchingRepository.java
+++ b/src/main/java/com/example/appcenter_project/repository/roommate/RoommateMatchingRepository.java
@@ -7,6 +7,7 @@ import com.example.appcenter_project.enums.roommate.MatchingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RoommateMatchingRepository extends JpaRepository<RoommateMatching, Long> {
 
@@ -15,5 +16,6 @@ public interface RoommateMatchingRepository extends JpaRepository<RoommateMatchi
     boolean existsBySenderAndStatus(User sender, MatchingStatus status);
     boolean existsByReceiverAndStatus(User receiver, MatchingStatus status);
 
+    Optional<RoommateMatching> findBySenderAndReceiverAndStatus(User sender, User receiver, MatchingStatus status);
 
 }


### PR DESCRIPTION
### 이슈번호
#197 

### 구현한 기능
- 내 룸메이트 정보 조회 API(/my-roommate/info)에서 매칭 ID도 함께 반환하도록 기능 추가
- ResponseMyRoommateInfoDto에 matchingId 필드 추가
- MyRoommateService에서 MyRoommate → RoommateMatching 정보를 찾아 matchingId를 세팅하도록 로직 수정

### 관련 사진
<img width="1276" height="1162" alt="image" src="https://github.com/user-attachments/assets/1eb67490-e37c-4bd9-8f79-286a73fa83eb" />
