### PR TITLE
fix: 채팅 메시지에 생성 시간(createdDate) 정확히 반환하도록 수정 #214

### DIFF
--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateChatDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateChatDto.java
@@ -14,6 +14,7 @@ public class ResponseRoommateChatDto {
     private Long userId;
     private String content;
     private boolean read;
+    private String createdDate;
 
     public static ResponseRoommateChatDto entityToDto(RoommateChattingChat chat) {
         return ResponseRoommateChatDto.builder()
@@ -22,6 +23,7 @@ public class ResponseRoommateChatDto {
                 .userId(chat.getMember().getId())
                 .content(chat.getContent())
                 .read(chat.isReadByReceiver())
+                .createdDate(chat.getCreatedDate().toString())
                 .build();
     }
 }


### PR DESCRIPTION
### 관련 이슈
#214 

### 구현한 기능
- ResponseRoommateChatDto에 createdDate 필드 추가
- entityToDto에서 채팅 생성 시간(chat.getCreatedDate())이 정확히 반환되도록 변경
- 프론트엔드에서 서버에서 내려준 시간만 사용하도록 안내

### 관련사진
<img width="1383" height="1257" alt="image" src="https://github.com/user-attachments/assets/4c260cd0-08f1-419f-998b-b8e42a012e50" />
