### PR TITLE
Jimin/chat profile image url 226

### DIFF
--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateChatApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateChatApiSpecification.java
@@ -2,6 +2,8 @@ package com.example.appcenter_project.controller.roommate;
 
 import com.example.appcenter_project.dto.request.roommate.RequestRoommateChatDto;
 import com.example.appcenter_project.dto.response.roommate.ResponseRoommateChatDto;
+import com.example.appcenter_project.dto.response.roommate.RoommateChatHistoryDto;
+import com.example.appcenter_project.dto.response.roommate.RoommateChatRoomDetailDto;
 import com.example.appcenter_project.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -9,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,22 +40,24 @@ public interface RoommateChatApiSpecification  {
     );
 
     @Operation(
-            summary = "채팅 내역 조회",
-            description = "채팅방에 입장 시, 해당 방의 전체 채팅 내역을 반환합니다.",
+            summary = "채팅방 상세 및 채팅 내역 조회",
+            description = "채팅방 입장 시, 상대방 정보 및 전체 채팅 내역을 반환합니다.",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "채팅 내역 조회 성공",
+                    @ApiResponse(responseCode = "200", description = "채팅방 상세 및 채팅 내역 조회 성공",
                             content = @Content(mediaType = "application/json",
-                                    schema = @Schema(implementation = ResponseRoommateChatDto.class))),
-                    @ApiResponse(responseCode = "404", description = "유저 또는 채팅방 없음 (USER_NOT_FOUND, ROOMMATE_CHAT_ROOM_NOT_FOUND)",
+                                    schema = @Schema(implementation = RoommateChatRoomDetailDto.class))),
+                    @ApiResponse(responseCode = "404", description = "유저 또는 채팅방 없음",
                             content = @Content()),
-                    @ApiResponse(responseCode = "403", description = "채팅방 권한 없음 (ROOMMATE_CHAT_ROOM_FORBIDDEN)",
+                    @ApiResponse(responseCode = "403", description = "채팅방 권한 없음",
                             content = @Content())
             }
     )
-    ResponseEntity<List<ResponseRoommateChatDto>> getChatList(
+    ResponseEntity<RoommateChatRoomDetailDto> getRoomDetail(
             @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "조회할 채팅방 ID", example = "1") @PathVariable Long roomId
+            @Parameter(description = "조회할 채팅방 ID", example = "1") @PathVariable Long roomId,
+            HttpServletRequest request
     );
+
 
     @Operation(
             summary = "채팅 읽음 처리",

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateChattingChatController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateChattingChatController.java
@@ -2,8 +2,11 @@ package com.example.appcenter_project.controller.roommate;
 
 import com.example.appcenter_project.dto.request.roommate.RequestRoommateChatDto;
 import com.example.appcenter_project.dto.response.roommate.ResponseRoommateChatDto;
+import com.example.appcenter_project.dto.response.roommate.RoommateChatHistoryDto;
+import com.example.appcenter_project.dto.response.roommate.RoommateChatRoomDetailDto;
 import com.example.appcenter_project.security.CustomUserDetails;
 import com.example.appcenter_project.service.roommate.RoommateChattingChatService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import jakarta.validation.Valid;
@@ -35,15 +38,18 @@ public class RoommateChattingChatController implements RoommateChatApiSpecificat
     }
 
     // 채팅 내역 조회
-    @GetMapping("/{roomId}")
-    public ResponseEntity<List<ResponseRoommateChatDto>> getChatList(
+    @GetMapping("/{roomId}/detail")
+    public ResponseEntity<RoommateChatRoomDetailDto> getRoomDetail(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long roomId
+            @PathVariable Long roomId,
+            HttpServletRequest request
     ) {
         Long userId = userDetails.getId();
-        List<ResponseRoommateChatDto> chatList = chatService.getChatList(userId, roomId);
-        return ResponseEntity.ok(chatList);
+        RoommateChatRoomDetailDto detail = chatService.getRoomDetail(userId, roomId, request);
+        return ResponseEntity.ok(detail);
     }
+
+
 
     // 읽음 처리
     @PatchMapping("/{roomId}/read")

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateChatRoomDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateChatRoomDto.java
@@ -16,4 +16,5 @@ public class ResponseRoommateChatRoomDto {
     private LocalDateTime lastMessageTime;
     private Long partnerId;
     private String partnerName;
+    private String partnerProfileImageUrl;
 }

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateChatRoomDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateChatRoomDto.java
@@ -16,5 +16,4 @@ public class ResponseRoommateChatRoomDto {
     private LocalDateTime lastMessageTime;
     private Long partnerId;
     private String partnerName;
-    private String partnerProfileImageUrl;
 }

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/RoommateChatHistoryDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/RoommateChatHistoryDto.java
@@ -1,0 +1,17 @@
+package com.example.appcenter_project.dto.response.roommate;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class RoommateChatHistoryDto {
+    private Long roommateChattingRoomId;
+    private Long roommateChatId;
+    private Long userId;
+    private String content;
+    private boolean read;
+    private String createdDate;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/RoommateChatRoomDetailDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/RoommateChatRoomDetailDto.java
@@ -1,0 +1,16 @@
+package com.example.appcenter_project.dto.response.roommate;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RoommateChatRoomDetailDto {
+    private Long roomId;
+    private Long partnerId;
+    private String partnerName;
+    private String partnerProfileImageUrl;
+    private List<RoommateChatHistoryDto> chatList;
+}


### PR DESCRIPTION
### 관련 이슈
#226 

### 구현한 기능
- 채팅방 상세정보에 상대방의 프로필 이미지 URL(partnerProfileImageUrl) 필드 추가
- 채팅 내역(chatList)의 각 메시지에도 보낸 사람의 이미지 URL 포함
- 채팅방 상세/내역 조회 시, partner와 각 메시지별 프로필 이미지 URL 조회 후 DTO에 포함
- 이미지가 없으면 null 

### 관련 이미지
<img width="1148" height="1077" alt="image" src="https://github.com/user-attachments/assets/24ed7dc9-4c31-4d8f-ab81-f4e5103e7d78" />
