### PR TITLE
Jimin/roommate board chat  image url 236

### DIFF
--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateApiSpecification.java
@@ -11,11 +11,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
+
 
 @Tag(name = "Roommate", description = "룸메이트 게시글 및 체크리스트 관련 API")
 public interface RoommateApiSpecification {
@@ -27,158 +29,80 @@ public interface RoommateApiSpecification {
                     @ApiResponse(responseCode = "201", description = "룸메이트 게시글 등록 성공",
                             content = @Content(mediaType = "application/json",
                                     schema = @Schema(implementation = ResponseRoommatePostDto.class))),
-                    @ApiResponse(responseCode = "404", description = "해당 유저가 존재하지 않습니다. (ROOMMATE_USER_NOT_FOUND)",
-                            content = @Content(examples = {}))
+                    @ApiResponse(responseCode = "404", description = "해당 유저가 존재하지 않습니다. (ROOMMATE_USER_NOT_FOUND)")
             }
     )
     ResponseEntity<ResponseRoommatePostDto> createRoommatePost(
             @Parameter(hidden = true) CustomUserDetails userDetails,
-
             @RequestBody
             @Parameter(description = "룸메이트 체크리스트 요청 DTO", required = true)
             RequestRoommateFormDto requestDto
+            // ※ 현재 컨트롤러가 request를 안 받으니 인터페이스도 받지 않음
     );
 
     @Operation(
             summary = "룸메이트 게시글 최신순 목록 조회",
-            description = "작성된 룸메이트 게시글을 최신순으로 조회합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공",
-                            content = @Content(mediaType = "application/json",
-                                    schema = @Schema(implementation = ResponseRoommatePostDto.class))),
-                    @ApiResponse(responseCode = "404", description = "게시글이 존재하지 않습니다. (ROOMMATE_BOARD_NOT_FOUND)",
-                            content = @Content(examples = {}))
-            }
+            description = "작성된 룸메이트 게시글을 최신순으로 조회합니다. (작성자 프로필 이미지 URL 포함)"
     )
-    ResponseEntity<List<ResponseRoommatePostDto>> getRoommateBoardList();
+    ResponseEntity<List<ResponseRoommatePostDto>> getRoommateBoardList(
+            @Parameter(hidden = true) HttpServletRequest request
+    );
 
     @Operation(
             summary = "룸메이트 게시글 단일 조회",
-            description = "특정 게시글 ID를 통해 룸메이트 게시글 상세 정보를 조회합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "게시글 상세 조회 성공",
-                            content = @Content(mediaType = "application/json",
-                                    schema = @Schema(implementation = ResponseRoommatePostDto.class))),
-                    @ApiResponse(responseCode = "404", description = "해당 게시글이 존재하지 않습니다. (ROOMMATE_BOARD_NOT_FOUND)",
-                            content = @Content(examples = {}))
-            }
+            description = "특정 게시글 ID를 통해 룸메이트 게시글 상세 정보를 조회합니다. (작성자 프로필 이미지 URL 포함)"
     )
     ResponseEntity<ResponseRoommatePostDto> getRoommateBoardDetail(
-            @Parameter(description = "조회할 게시글 ID", example = "1")
-            @PathVariable Long boardId
+            @Parameter(description = "조회할 게시글 ID", example = "1") @PathVariable Long boardId,
+            @Parameter(hidden = true) HttpServletRequest request
     );
 
     @Operation(
             summary = "유사한 룸메이트 게시글 추천",
-            description = "로그인한 사용자의 체크리스트 기준으로 유사한 게시글을 추천합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "추천 게시글 목록 조회 성공",
-                            content = @Content(mediaType = "application/json",
-                                    schema = @Schema(implementation = ResponseRoommateSimilarityDto.class))),
-                    @ApiResponse(responseCode = "404", description = "유사도 비교할 게시글이 없습니다 (ROOMMATE_NO_SIMILAR_BOARD)",
-                            content = @Content(examples = {}))
-            }
+            description = "로그인한 사용자의 체크리스트 기준으로 유사한 게시글을 추천합니다. (작성자 프로필 이미지 URL 포함)"
     )
     ResponseEntity<List<ResponseRoommateSimilarityDto>> getSimilarRoommates(
-            @Parameter(hidden = true) CustomUserDetails userDetails
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @Parameter(hidden = true) HttpServletRequest request
     );
 
     @Operation(
             summary = "룸메이트 체크리스트 및 게시글 수정",
-            description = "기존에 작성한 룸메이트 체크리스트 및 게시글을 수정합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "수정 성공",
-                            content = @Content(mediaType = "application/json",
-                                    schema = @Schema(implementation = ResponseRoommatePostDto.class))),
-                    @ApiResponse(responseCode = "404", description = "해당 유저 또는 게시글/체크리스트가 존재하지 않음 (ROOMMATE_USER_NOT_FOUND, ROOMMATE_BOARD_NOT_FOUND, ROOMMATE_CHECKLIST_NOT_FOUND)",
-                            content = @Content(examples = {})),
-                    @ApiResponse(responseCode = "403", description = "본인이 작성한 체크리스트가 아님 (ROOMMATE_UPDATE_NOT_ALLOWED)",
-                            content = @Content(examples = {})),
-                    @ApiResponse(responseCode = "500", description = "체크리스트 수정 실패 (ROOMMATE_CHECKLIST_UPDATE_FAILED)",
-                            content = @Content(examples = {}))
-            }
+            description = "기존에 작성한 룸메이트 체크리스트 및 게시글을 수정합니다. (작성자 프로필 이미지 URL 포함)"
     )
     ResponseEntity<ResponseRoommatePostDto> updateRoommateCheckListAndBoard(
             @Parameter(hidden = true) CustomUserDetails userDetails,
-
             @RequestBody
             @Parameter(description = "수정할 룸메이트 체크리스트 요청 DTO", required = true)
-            RequestRoommateFormDto requestDto
+            RequestRoommateFormDto requestDto,
+            @Parameter(hidden = true) HttpServletRequest request
     );
 
-    @Operation(
-            summary = "룸메이트 게시글 좋아요",
-            description = "특정 게시글에 좋아요를 추가합니다. 이미 좋아요를 누른 경우 에러가 발생합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "좋아요 성공, 현재 좋아요 개수 반환",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Integer.class))),
-                    @ApiResponse(responseCode = "404", description = "해당 유저 또는 게시글이 존재하지 않음 (ROOMMATE_USER_NOT_FOUND, ROOMMATE_BOARD_NOT_FOUND)", content = @Content),
-                    @ApiResponse(responseCode = "401", description = "이미 좋아요를 누른 유저 (ALREADY_ROOMMATE_BOARD_LIKE_USER)", content = @Content)
-            }
-    )
+    @Operation(summary = "룸메이트 게시글 좋아요")
     ResponseEntity<Integer> plusLike(
             @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "좋아요를 누를 게시글 ID", example = "1")
-            @PathVariable Long boardId
+            @Parameter(description = "좋아요를 누를 게시글 ID", example = "1") @PathVariable Long boardId
     );
 
-    @Operation(
-            summary = "룸메이트 게시글 좋아요 취소",
-            description = "특정 게시글의 좋아요를 취소합니다. 좋아요를 누르지 않은 경우 에러가 발생합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "좋아요 취소 성공, 현재 좋아요 개수 반환",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Integer.class))),
-                    @ApiResponse(responseCode = "404", description = "해당 유저, 게시글 또는 좋아요 정보가 없음 (ROOMMATE_USER_NOT_FOUND, ROOMMATE_BOARD_NOT_FOUND, ROOMMATE_BOARD_LIKE_NOT_FOUND)", content = @Content)
-            }
-    )
+    @Operation(summary = "룸메이트 게시글 좋아요 취소")
     ResponseEntity<Integer> minusLike(
             @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "좋아요 취소할 게시글 ID", example = "1")
-            @PathVariable Long boardId
+            @Parameter(description = "좋아요 취소할 게시글 ID", example = "1") @PathVariable Long boardId
     );
 
-    @Operation(
-            summary = "룸메이트 게시글 주인의 매칭 여부 조회",
-            description = "특정 게시글의 작성자가 이미 매칭(COMPLETED) 상태인지 확인합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "매칭 여부 반환",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Boolean.class))),
-                    @ApiResponse(responseCode = "404", description = "게시글이 존재하지 않음 (ROOMMATE_BOARD_NOT_FOUND)", content = @Content)
-            }
-    )
+    @Operation(summary = "룸메이트 게시글 주인의 매칭 여부 조회")
     ResponseEntity<Boolean> isBoardOwnerMatched(
-            @Parameter(description = "조회할 게시글 ID", example = "1")
-            @PathVariable Long boardId
+            @Parameter(description = "조회할 게시글 ID", example = "1") @PathVariable Long boardId
     );
 
-    @Operation(
-            summary = "룸메이트 게시글 좋아요 여부 조회",
-            description = "특정 게시글에 로그인한 사용자가 좋아요를 눌렀는지 여부를 반환합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "좋아요 여부 반환 (true: 좋아요 누름, false: 안 누름)",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Boolean.class))),
-                    @ApiResponse(responseCode = "404", description = "해당 게시글이 존재하지 않음 (ROOMMATE_BOARD_NOT_FOUND)", content = @Content),
-                    @ApiResponse(responseCode = "404", description = "해당 유저가 존재하지 않음 (ROOMMATE_USER_NOT_FOUND)", content = @Content)
-            }
-    )
+    @Operation(summary = "룸메이트 게시글 좋아요 여부 조회")
     ResponseEntity<Boolean> isRoommateBoardLiked(
-            @Parameter(description = "조회할 게시글 ID", example = "1")
-            @PathVariable Long boardId,
+            @Parameter(description = "조회할 게시글 ID", example = "1") @PathVariable Long boardId,
             @Parameter(hidden = true) CustomUserDetails userDetails
     );
 
-    @Operation(
-            summary = "내 룸메이트 체크리스트 단일 조회",
-            description = "로그인한 사용자가 작성한 체크리스트를 단일 조회합니다.",
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "내 체크리스트 조회 성공",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseRoommateCheckListDto.class))),
-                    @ApiResponse(responseCode = "404", description = "체크리스트 없음", content = @Content)
-            }
-    )
+    @Operation(summary = "내 룸메이트 체크리스트 단일 조회")
     ResponseEntity<ResponseRoommateCheckListDto> getMyRoommateCheckList(
             @Parameter(hidden = true) CustomUserDetails userDetails
     );
-
-
 }

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateChattingRoomApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateChattingRoomApiSpecification.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import jakarta.servlet.http.HttpServletRequest;   // 추가
 
 import java.util.List;
 
@@ -36,7 +37,7 @@ public interface RoommateChattingRoomApiSpecification {
             summary = "채팅방 나가기",
             description = "게스트가 특정 채팅방에서 나가며 채팅방이 삭제됩니다.",
             responses = {
-                    @ApiResponse(responseCode = "201", description = "나가기 성공 (채팅방 삭제)"),
+                    @ApiResponse(responseCode = "204", description = "나가기 성공"),
                     @ApiResponse(responseCode = "404", description = "유저 또는 채팅방을 찾을 수 없음"),
                     @ApiResponse(responseCode = "403", description = "게스트가 아닌 사용자의 접근")
             }
@@ -57,7 +58,8 @@ public interface RoommateChattingRoomApiSpecification {
             }
     )
     ResponseEntity<List<ResponseRoommateChatRoomDto>> getRoommateChatRoomList(
-            @Parameter(hidden = true) CustomUserDetails userDetails
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @Parameter(hidden = true) HttpServletRequest request   // 추가
     );
 
     @Operation(
@@ -75,6 +77,4 @@ public interface RoommateChattingRoomApiSpecification {
             @Parameter(hidden = true) CustomUserDetails user,
             @Parameter(description = "채팅방 ID") Long chatRoomId
     );
-
-
 }

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateChattingRoomController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateChattingRoomController.java
@@ -5,6 +5,7 @@ import com.example.appcenter_project.dto.response.roommate.ResponseRoommateCheck
 import com.example.appcenter_project.entity.roommate.RoommateCheckList;
 import com.example.appcenter_project.security.CustomUserDetails;
 import com.example.appcenter_project.service.roommate.RoommateChattingRoomService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,6 +23,7 @@ public class RoommateChattingRoomController implements RoommateChattingRoomApiSp
     private final RoommateChattingRoomService roommateChattingRoomService;
 
     // 게스트가 채팅방 참여 요청
+    @Override
     @PostMapping("/board/{roommateBoardId}")
     public ResponseEntity<Long> createChatRoom(@AuthenticationPrincipal CustomUserDetails user,
                                                @PathVariable Long roommateBoardId) {
@@ -30,6 +32,7 @@ public class RoommateChattingRoomController implements RoommateChattingRoomApiSp
     }
 
     // 채팅방 나가기 (게스트 기준)
+    @Override
     @DeleteMapping("/{chatRoomId}")
     public ResponseEntity<Void> leaveChatRoom(@AuthenticationPrincipal CustomUserDetails user,
                                               @PathVariable Long chatRoomId) {
@@ -38,14 +41,19 @@ public class RoommateChattingRoomController implements RoommateChattingRoomApiSp
     }
 
     // 채팅방 목록 조회
+    @Override
     @GetMapping
     public ResponseEntity<List<ResponseRoommateChatRoomDto>> getRoommateChatRoomList(
-            @AuthenticationPrincipal CustomUserDetails user) {
-        List<ResponseRoommateChatRoomDto> chatRooms = roommateChattingRoomService.findRoommateChatRoomListByUser(user);
+            @AuthenticationPrincipal CustomUserDetails user,
+            HttpServletRequest request // 추가
+    ) {
+        List<ResponseRoommateChatRoomDto> chatRooms =
+                roommateChattingRoomService.findRoommateChatRoomListByUser(user, request); // 변경
         return ResponseEntity.ok(chatRooms);
     }
 
     //상대방 체크리스트 확인
+    @Override
     @GetMapping("/roommate-chatrooms/{chatRoomId}/opponent-checklist")
     public ResponseEntity<ResponseRoommateCheckListDto> getOpponentChecklist(
             @AuthenticationPrincipal CustomUserDetails user,

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateController.java
@@ -20,6 +20,7 @@ public class RoommateController implements RoommateApiSpecification{
 
     private final RoommateService roommateService;
 
+    @Override
     @PostMapping
     public ResponseEntity<ResponseRoommatePostDto> createRoommatePost(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -30,35 +31,47 @@ public class RoommateController implements RoommateApiSpecification{
         return ResponseEntity.status(201).body(responseDto);
     }
 
+    @Override
     @GetMapping("/list")
-    public ResponseEntity<List<ResponseRoommatePostDto>> getRoommateBoardList() {
-        return ResponseEntity.ok(roommateService.getRoommateBoardList());
+    public ResponseEntity<List<ResponseRoommatePostDto>> getRoommateBoardList(
+            jakarta.servlet.http.HttpServletRequest request
+    ) {
+        return ResponseEntity.ok(roommateService.getRoommateBoardList(request));
     }
 
+    @Override
     @GetMapping("/{boardId}")
-    public ResponseEntity<ResponseRoommatePostDto> getRoommateBoardDetail(@PathVariable Long boardId){
-        return ResponseEntity.ok(roommateService.getRoommateBoardDetail(boardId));
+    public ResponseEntity<ResponseRoommatePostDto> getRoommateBoardDetail(
+            @PathVariable Long boardId,
+            jakarta.servlet.http.HttpServletRequest request
+    ){
+        return ResponseEntity.ok(roommateService.getRoommateBoardDetail(boardId, request));
     }
 
+    @Override
     @GetMapping("/similar")
     public ResponseEntity<List<ResponseRoommateSimilarityDto>> getSimilarRoommates(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-
-        Long userId = userDetails.getId(); // 로그인된 사용자의 ID 가져오기
-        List<ResponseRoommateSimilarityDto> similarList = roommateService.getSimilarRoommateBoards(userId);
-        return ResponseEntity.ok(similarList);
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            jakarta.servlet.http.HttpServletRequest request
+    ) {
+        Long userId = userDetails.getId();
+        return ResponseEntity.ok(roommateService.getSimilarRoommateBoards(userId, request));
     }
 
+    @Override
     @PutMapping
     public ResponseEntity<ResponseRoommatePostDto> updateRoommateCheckListAndBoard(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody RequestRoommateFormDto requestDto) {
-
+            @RequestBody RequestRoommateFormDto requestDto,
+            jakarta.servlet.http.HttpServletRequest request // 추가
+    ) {
         Long userId = userDetails.getId();
-        ResponseRoommatePostDto updated = roommateService.updateRoommateChecklistAndBoard(requestDto, userId);
+        ResponseRoommatePostDto updated =
+                roommateService.updateRoommateChecklistAndBoard(requestDto, userId, request); // 변경
         return ResponseEntity.ok(updated);
     }
 
+    @Override
     @PostMapping("/{boardId}/like")
     public ResponseEntity<Integer> plusLike(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -68,6 +81,7 @@ public class RoommateController implements RoommateApiSpecification{
         return ResponseEntity.ok(likeCount);
     }
 
+    @Override
     @DeleteMapping("/{boardId}/like")
     public ResponseEntity<Integer> minusLike(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -77,12 +91,14 @@ public class RoommateController implements RoommateApiSpecification{
         return ResponseEntity.ok(likeCount);
     }
 
+    @Override
     @GetMapping("/{boardId}/owner-matched")
     public ResponseEntity<Boolean> isBoardOwnerMatched(@PathVariable Long boardId) {
         boolean matched = roommateService.isRoommateBoardOwnerMatched(boardId);
         return ResponseEntity.ok(matched);
     }
 
+    @Override
     @GetMapping("/{boardId}/liked")
     public ResponseEntity<Boolean> isRoommateBoardLiked(
             @PathVariable Long boardId,
@@ -93,6 +109,7 @@ public class RoommateController implements RoommateApiSpecification{
         return ResponseEntity.ok(isLiked);
     }
 
+    @Override
     @GetMapping("/my-checklist")
     public ResponseEntity<ResponseRoommateCheckListDto> getMyRoommateCheckList(
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateChatRoomDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateChatRoomDto.java
@@ -16,4 +16,5 @@ public class ResponseRoommateChatRoomDto {
     private LocalDateTime lastMessageTime;
     private Long partnerId;
     private String partnerName;
+    private String partnerProfileImageUrl;
 }

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommatePostDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommatePostDto.java
@@ -34,6 +34,7 @@ public class ResponseRoommatePostDto extends ResponseBoardDto {
     private Long userId;
     private String userName;
     private boolean isMatched;
+    private String userProfileImageUrl;
 
     @Builder
     public ResponseRoommatePostDto(Long id, String title, String type, LocalDateTime createDate, String filePath,
@@ -41,7 +42,8 @@ public class ResponseRoommatePostDto extends ResponseBoardDto {
                                    String mbti, SmokingType smoking, SnoringType snoring, TeethGrindingType toothGrind,
                                    SleepSensitivityType sleeper, ShowerTimeType showerHour, ShowerDurationType showerTime,
                                    BedTimeType bedTime, CleanlinessType arrangement, String comment,
-                                   int roommateBoardLike, Long userId, String userName, boolean isMatched) {
+                                   int roommateBoardLike, Long userId, String userName, boolean isMatched,
+                                   String userProfileImageUrl) {
         super(id, title, type, createDate, filePath);
         this.dormPeriod = dormPeriod;
         this.dormType = dormType;
@@ -61,9 +63,10 @@ public class ResponseRoommatePostDto extends ResponseBoardDto {
         this.userId = userId;
         this.userName = userName;
         this.isMatched = isMatched;
+        this.userProfileImageUrl = userProfileImageUrl;
     }
 
-    public static ResponseRoommatePostDto entityToDto(RoommateBoard board, boolean isMatched) {
+    public static ResponseRoommatePostDto entityToDto(RoommateBoard board, boolean isMatched, String userProfileImageUrl) {
         RoommateCheckList cl = board.getRoommateCheckList();
         User user = board.getUser();
 
@@ -91,6 +94,7 @@ public class ResponseRoommatePostDto extends ResponseBoardDto {
                 .userId(user.getId())
                 .userName(user.getName())
                 .isMatched(isMatched)
+                .userProfileImageUrl(userProfileImageUrl)
                 .build();
     }
 }

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateSimilarityDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateSimilarityDto.java
@@ -34,6 +34,7 @@ public class ResponseRoommateSimilarityDto {
     private String userName;
     private LocalDateTime createdDate;
     private boolean isMatched;
+    private String userProfileImageUrl;
 
     private int roommateBoardLike;
     private Integer similarityPercentage;

--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateChattingRoomService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateChattingRoomService.java
@@ -38,6 +38,8 @@ public class RoommateChattingRoomService {
     private final RoommateChattingRoomRepository roommateChattingRoomRepository;
     private final RoommateBoardRepository roommateBoardRepository;
     private final UserRepository userRepository;
+    private final com.example.appcenter_project.service.image.ImageService imageService;
+
 
     //채팅방 생성
     @Transactional
@@ -105,7 +107,10 @@ public class RoommateChattingRoomService {
     }
 
     @Transactional(readOnly = true)
-    public List<ResponseRoommateChatRoomDto> findRoommateChatRoomListByUser(CustomUserDetails userDetails) {
+    public List<ResponseRoommateChatRoomDto> findRoommateChatRoomListByUser(
+            CustomUserDetails userDetails,
+            jakarta.servlet.http.HttpServletRequest request
+    ) {
         User user = userRepository.findById(userDetails.getId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
@@ -115,29 +120,28 @@ public class RoommateChattingRoomService {
         int index = 1;
 
         for (RoommateChattingRoom room : rooms) {
-            // 익명 N 설정
             String opponentNickname = "익명 " + index++;
 
-            // 마지막 메시지
             Optional<RoommateChattingChat> lastChat = room.getChattingChatList().stream()
                     .max(Comparator.comparing(RoommateChattingChat::getCreatedDate));
 
             String lastMessage = lastChat.map(RoommateChattingChat::getContent).orElse("");
             LocalDateTime lastMessageTime = lastChat.map(RoommateChattingChat::getCreatedDate).orElse(null);
 
-            // 상대방 정보 획득
-            User partner = null;
-
             User host = room.getHost();
             User guest = room.getGuest();
+            User partner = host.getId().equals(user.getId()) ? guest : host;
 
-            if (host.getId().equals(user.getId())) {
-                partner = guest;
-            } else {
-                partner = host;
+            // ImageService의 정적 리소스 URL(fileName)을 사용
+            String partnerProfileImageUrl = null;
+            try {
+                partnerProfileImageUrl =
+                        imageService.findUserImageUrlByUserId(partner.getId(), request).getFileName();
+            } catch (Exception e) {
+                // 기본이미지 초기화 로직이 있으므로 실패 시 null 허용
+                log.warn("partner image url resolve failed. userId={}", partner.getId(), e);
             }
 
-            // DTO 생성
             result.add(ResponseRoommateChatRoomDto.builder()
                     .chatRoomId(room.getId())
                     .opponentNickname(opponentNickname)
@@ -145,15 +149,17 @@ public class RoommateChattingRoomService {
                     .lastMessageTime(lastMessageTime)
                     .partnerName(partner.getName())
                     .partnerId(partner.getId())
+                    .partnerProfileImageUrl(partnerProfileImageUrl)
                     .build());
         }
 
-        // 마지막 메시지 시간 기준 내림차순 정렬 (null은 맨 뒤)
-        result.sort(Comparator.comparing(ResponseRoommateChatRoomDto::getLastMessageTime,
+        result.sort(Comparator.comparing(
+                ResponseRoommateChatRoomDto::getLastMessageTime,
                 Comparator.nullsLast(Comparator.reverseOrder())));
 
         return result;
     }
+
 
     @Transactional(readOnly = true)
     public RoommateCheckList getOpponentChecklist(Long userId, Long chatRoomId) {

--- a/src/main/java/com/example/appcenter_project/service/user/UserService.java
+++ b/src/main/java/com/example/appcenter_project/service/user/UserService.java
@@ -163,7 +163,7 @@ public class UserService {
         List<RoommateBoardLike> likeRoommateBoardLikes = roommateBoardLikeRepository.findByUserId(userId);
         for (RoommateBoardLike likeRoommateBoardLike : likeRoommateBoardLikes) {
             RoommateBoard roommateBoard = likeRoommateBoardLike.getRoommateBoard();
-            ResponseRoommatePostDto responseRoommatePostDto = ResponseRoommatePostDto.entityToDto(roommateBoard, false);
+            ResponseRoommatePostDto responseRoommatePostDto = ResponseRoommatePostDto.entityToDto(roommateBoard, false,null);
             responseLikeDtoList.add(responseRoommatePostDto);
         }
 


### PR DESCRIPTION
### 관련 이슈
#236 

### 구현한 기능
- 게시글 응답에 프로필 이미지 URL 추가: 목록/상세/유사도/수정 응답에 userProfileImageUrl 포함.
- 컨트롤러–서비스 시그니처 정리: HttpServletRequest를 전달하도록 list/detail/similar/update 엔드포인트 수정.
- 좋아요 목록 매핑 수정: UserService.findLikeByUserId에서 entityToDto(..., false, null)로 변경 반영.
- 문서) Swagger 스키마에 userProfileImageUrl 반영, HttpServletRequest는 숨김 처리.

### 관련 스크린샷
-룸메이트 게시글 조회
<img width="1175" height="1261" alt="image" src="https://github.com/user-attachments/assets/ff4609cf-377d-41d0-b726-075df474c07e" />
<img width="1110" height="1325" alt="image" src="https://github.com/user-attachments/assets/14085a5d-c711-4277-bfcc-773da0d8805b" />
![Uploading image.png…]()


-채팅방 모록
<img width="1190" height="1111" alt="Image" src="https://github.com/user-attachments/assets/b6ed91ff-5840-4b79-8557-e55fe5690851" />