### PR TITLE
Jimin/save token update 328

### DIFF
--- a/src/main/java/com/example/appcenter_project/entity/user/FcmToken.java
+++ b/src/main/java/com/example/appcenter_project/entity/user/FcmToken.java
@@ -25,4 +25,8 @@ public class FcmToken {
         this.user = user;
         this.token = token;
     }
+
+    public void updateToken(String newToken) {
+        this.token = newToken;
+    }
 }

--- a/src/main/java/com/example/appcenter_project/repository/user/FcmTokenRepository.java
+++ b/src/main/java/com/example/appcenter_project/repository/user/FcmTokenRepository.java
@@ -1,8 +1,12 @@
 package com.example.appcenter_project.repository.user;
 
 import com.example.appcenter_project.entity.user.FcmToken;
+import com.example.appcenter_project.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface FcmTokenRepository extends JpaRepository<FcmToken,Long> {
     void deleteByToken(String targetToken);
+    boolean existsByToken(String token);
+    Optional<FcmToken> findByUser(User user);
 }


### PR DESCRIPTION
## 이슈번호
#328 

## 작업한 내용
- FcmToken 엔티티에 updateToken() 메서드 추가
- FcmTokenRepository에 existsByToken, findByUser, deleteByToken 메서드 추가
- FcmTokenService 리팩토링
   - 중복 토큰 저장 방지
   - 기존 유저 토큰 갱신 처리
   - 신규 유저 토큰 생성
  
## 관련 이미지
<img width="1477" height="1377" alt="image" src="https://github.com/user-attachments/assets/ee59fdd6-3531-49bd-bd7c-7cc4f6251a5d" />
