### PR TITLE
Jimin/fcm send all users 331

### DIFF
--- a/src/main/java/com/example/appcenter_project/controller/fcm/FcmApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/fcm/FcmApiSpecification.java
@@ -30,6 +30,34 @@ public interface FcmApiSpecification {
             RequestFcmTokenDto requestDto
     );
 
+    @Operation(
+            summary = "전체 사용자에게 FCM 알림 전송",
+            description = "모든 사용자(로그인하지 않은 사용자 포함)의 FCM 토큰을 대상으로 알림을 발송합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "전체 사용자에게 메시지 전송 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseFcmMessageDto.class))
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "보낼 FCM 토큰이 존재하지 않음",
+                            content = @Content()
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "FCM 발송 중 서버 오류 발생",
+                            content = @Content()
+                    )
+            }
+    )
+    ResponseEntity<ResponseFcmMessageDto> sendMessageToAllUsers(
+            @RequestBody @Parameter(description = "전체 사용자에게 보낼 알림 메시지 요청 DTO", required = true)
+            RequestFcmMessageDto requestDto
+    );
+
+
 /*    @Operation(
             summary = "FCM 메시지 발송",
             description = "지정한 targetToken으로 푸시 알림을 발송합니다.",

--- a/src/main/java/com/example/appcenter_project/controller/fcm/FcmController.java
+++ b/src/main/java/com/example/appcenter_project/controller/fcm/FcmController.java
@@ -28,6 +28,20 @@ public class FcmController implements FcmApiSpecification{
         return ResponseEntity.ok().build();
     }
 
+    // 전체 사용자에게 알림 전송 (user_id가 NULL인 토큰도 포함)
+    @PostMapping("/send/all")
+    public ResponseEntity<ResponseFcmMessageDto> sendMessageToAllUsers(
+            @RequestBody RequestFcmMessageDto requestDto
+    ) {
+        ResponseFcmMessageDto response = fcmMessageService.sendNotificationToAllUsers(
+                requestDto.getTitle(),
+                requestDto.getBody()
+        );
+        return ResponseEntity.ok(response);
+    }
+
+
+
 /*    @PostMapping("/send")
     public ResponseEntity<ResponseFcmMessageDto> sendMessage(
             @RequestBody RequestFcmMessageDto requestDto

--- a/src/main/java/com/example/appcenter_project/dto/request/fcm/RequestFcmMessageDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/request/fcm/RequestFcmMessageDto.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class RequestFcmMessageDto {
-    private String targetToken;
     private String title;
     private String body;
 }

--- a/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
+++ b/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
@@ -123,7 +123,11 @@ public enum ErrorCode {
     USER_GROUP_ORDER_KEYWORD_NOT_FOUND(NOT_FOUND, 15001, "[UserGroupOrderKeyword] 해당 유저공동구매키워드를 찾을 수 없습니다."),
 
     // POPUP_NOTIFICATION
-    POPUP_NOTIFICATION_NOT_FOUND(NOT_FOUND, 16001, "[PopupNotification] 해당 팝업 공지를 찾을 수 없습니다.");
+    POPUP_NOTIFICATION_NOT_FOUND(NOT_FOUND, 16001, "[PopupNotification] 해당 팝업 공지를 찾을 수 없습니다."),
+
+    // FCM
+    FCM_TOKEN_NOT_FOUND(NOT_FOUND, 17001, "[FCM] 전체 사용자에게 보낼 FCM 토큰이 존재하지 않습니다."),
+    FCM_SEND_FAILED(INTERNAL_SERVER_ERROR, 17002, "[FCM] FCM 메시지 전송 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/appcenter_project/service/fcm/FcmMessageService.java
+++ b/src/main/java/com/example/appcenter_project/service/fcm/FcmMessageService.java
@@ -1,14 +1,19 @@
 package com.example.appcenter_project.service.fcm;
 
+import com.example.appcenter_project.dto.response.fcm.ResponseFcmMessageDto;
 import com.example.appcenter_project.entity.user.FcmToken;
 import com.example.appcenter_project.entity.user.User;
+import com.example.appcenter_project.exception.CustomException;
+import com.example.appcenter_project.exception.ErrorCode;
 import com.example.appcenter_project.repository.user.FcmTokenRepository;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
 
 @Service
 @Slf4j
@@ -45,4 +50,43 @@ public class FcmMessageService {
         // todo 임시로 null
         return null;
     }
+
+    // 추가: 전체 사용자(회원 + 비회원)에게 전송
+    public ResponseFcmMessageDto sendNotificationToAllUsers(String title, String body) {
+        List<FcmToken> allTokens = fcmTokenRepository.findAll();
+
+        if (allTokens.isEmpty()) {
+            log.warn("No FCM tokens found. 전체 사용자에게 보낼 토큰이 없습니다.");
+            throw new CustomException(ErrorCode.FCM_TOKEN_NOT_FOUND);
+        }
+
+        for (FcmToken fcmToken : allTokens) {
+            String targetToken = fcmToken.getToken();
+
+            Notification notification = Notification.builder()
+                    .setTitle(title)
+                    .setBody(body)
+                    .build();
+
+            Message message = Message.builder()
+                    .setToken(targetToken)
+                    .setNotification(notification)
+                    .build();
+
+            try {
+                String response = FirebaseMessaging.getInstance().send(message);
+                log.info("Successfully sent FCM message to token: {}", response);
+            } catch (Exception e) {
+                log.error("Error sending FCM message to token: {}", targetToken, e);
+                fcmTokenRepository.deleteByToken(targetToken);
+                throw new CustomException(ErrorCode.FCM_SEND_FAILED);
+            }
+        }
+
+        return ResponseFcmMessageDto.builder()
+                .messageId("ALL_USERS")
+                .status("SUCCESS")
+                .build();
+    }
+
 }

--- a/src/main/java/com/example/appcenter_project/service/fcm/FcmMessageService.java
+++ b/src/main/java/com/example/appcenter_project/service/fcm/FcmMessageService.java
@@ -13,6 +13,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -52,6 +53,7 @@ public class FcmMessageService {
     }
 
     // 추가: 전체 사용자(회원 + 비회원)에게 전송
+    @Transactional
     public ResponseFcmMessageDto sendNotificationToAllUsers(String title, String body) {
         List<FcmToken> allTokens = fcmTokenRepository.findAll();
 


### PR DESCRIPTION
## 이슈
#331 

## 구현한 기능
- 전체 사용자에게 FCM 알림을 전송하는 기능 추가
- user_id가 NULL인 토큰(비회원 포함)도 알림 발송 대상에 포함
- /fcm/send/all 엔드포인트 구현 및 Swagger 명세 추가

## 이미지
<img width="1388" height="711" alt="image" src="https://github.com/user-attachments/assets/8f18f597-a415-411d-ae3e-eae44cbc6157" />
