### PR TITLE
Jimin/complaint notification system 349

### DIFF
--- a/src/main/java/com/example/appcenter_project/dto/request/complaint/RequestComplaintDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/request/complaint/RequestComplaintDto.java
@@ -10,9 +10,9 @@ import lombok.NoArgsConstructor;
 public class RequestComplaintDto {
 
     @Schema(description = "민원 유형", 
-            example = "기물", 
-            allowableValues = {"기물", "시설", "청소/위생", "소음", "기타"})
-    private String type;        // 유형 (기물, 시설, 청소/위생, 소음, 기타)
+            example = "소음",
+            allowableValues = {"소음", "흡연", "음주", "룸메이트변경", "벌점상쇄","벌점사유확인"})
+    private String type;
     
     @Schema(description = "기숙사 구분", 
             example = "1기숙사", 

--- a/src/main/java/com/example/appcenter_project/enums/user/NotificationType.java
+++ b/src/main/java/com/example/appcenter_project/enums/user/NotificationType.java
@@ -13,7 +13,8 @@ public enum NotificationType {
     GROUP_ORDER("공동구매"),
     DORMITORY("생활원"),
     UNI_DORM("유니돔"),
-    SUPPORTERS("서포터즈");
+    SUPPORTERS("서포터즈"),
+    COMPLAINT("민원");
 
     private final String description;
 

--- a/src/main/java/com/example/appcenter_project/service/complaint/ComplaintService.java
+++ b/src/main/java/com/example/appcenter_project/service/complaint/ComplaintService.java
@@ -22,6 +22,7 @@ import com.example.appcenter_project.repository.complaint.ComplaintRepository;
 import com.example.appcenter_project.repository.complaint.ComplaintSpecification;
 import com.example.appcenter_project.repository.image.ImageRepository;
 import com.example.appcenter_project.repository.user.UserRepository;
+import com.example.appcenter_project.service.notification.AdminComplaintNotificationService;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -52,6 +53,7 @@ public class ComplaintService {
     private final UserRepository userRepository;
     private final ImageRepository imageRepository;
     private final AttachedFileRepository attachedFileRepository;
+    private final AdminComplaintNotificationService adminComplaintNotificationService;
     private final ImageService imageService;
 
     // 민원 등록
@@ -89,6 +91,14 @@ public class ComplaintService {
         // 이미지 저장
         if (images != null && !images.isEmpty()) {
             imageService.saveImages(ImageType.COMPLAINT, complaint.getId(), images);
+        }
+
+        // 관리자에게 새 민원 접수 알림 발송
+        try {
+            adminComplaintNotificationService.sendNewComplaintNotification(saved.getId());
+            log.info("관리자 새 민원 알림 발송 완료 - 민원ID: {}", saved.getId());
+        } catch (Exception e) {
+            log.error("관리자 새 민원 알림 발송 실패 - 민원ID: {}", saved.getId(), e);
         }
 
         return ResponseComplaintDto.builder()

--- a/src/main/java/com/example/appcenter_project/service/notification/AdminComplaintNotificationService.java
+++ b/src/main/java/com/example/appcenter_project/service/notification/AdminComplaintNotificationService.java
@@ -1,0 +1,170 @@
+package com.example.appcenter_project.service.notification;
+
+import com.example.appcenter_project.entity.complaint.Complaint;
+import com.example.appcenter_project.entity.notification.Notification;
+import com.example.appcenter_project.entity.notification.UserNotification;
+import com.example.appcenter_project.entity.user.User;
+import com.example.appcenter_project.enums.complaint.ComplaintStatus;
+import com.example.appcenter_project.enums.user.NotificationType;
+import com.example.appcenter_project.enums.user.Role;
+import com.example.appcenter_project.exception.CustomException;
+import com.example.appcenter_project.repository.complaint.ComplaintRepository;
+import com.example.appcenter_project.repository.notification.NotificationRepository;
+import com.example.appcenter_project.repository.notification.UserNotificationRepository;
+import com.example.appcenter_project.repository.user.UserRepository;
+import com.example.appcenter_project.service.fcm.FcmMessageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.example.appcenter_project.exception.ErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class AdminComplaintNotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserNotificationRepository userNotificationRepository;
+    private final UserRepository userRepository;
+    private final ComplaintRepository complaintRepository;
+    private final FcmMessageService fcmMessageService;
+
+    /**
+     * 새 민원 접수 시 관리자에게 알림 발송
+     */
+    public void sendNewComplaintNotification(Long complaintId) {
+        Complaint complaint = complaintRepository.findById(complaintId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        
+        String title = "생활원 민원";
+        String body = "새로운 민원이 접수되었습니다\n민원 제목: " + complaint.getTitle();
+        
+        // 주말/퇴근시간 체크
+        if (shouldDelayNotification()) {
+            scheduleDelayedNotification(complaintId, title, body, "NEW_COMPLAINT");
+            return;
+        }
+        
+        sendToAllAdmins(complaintId, title, body);
+    }
+
+    /**
+     * 민원 상태 변경 시 관리자에게 알림 발송
+     */
+    public void sendStatusChangeNotification(Long complaintId, ComplaintStatus oldStatus, ComplaintStatus newStatus) {
+        Complaint complaint = complaintRepository.findById(complaintId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        
+        String title = "생활원 민원";
+        String body = getStatusChangeMessage(oldStatus, newStatus) + "\n민원 제목: " + complaint.getTitle();
+        
+        // 주말/퇴근시간 체크
+        if (shouldDelayNotification()) {
+            scheduleDelayedNotification(complaintId, title, body, "STATUS_CHANGE");
+            return;
+        }
+        
+        sendToAllAdmins(complaintId, title, body);
+    }
+
+    /**
+     * 주말/퇴근시간 이후인지 체크
+     */
+    private boolean shouldDelayNotification() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalTime currentTime = now.toLocalTime();
+        
+        // 주말 체크 (토요일=6, 일요일=7)
+        int dayOfWeek = now.getDayOfWeek().getValue();
+        if (dayOfWeek == 6 || dayOfWeek == 7) {
+            return true;
+        }
+        
+        // 퇴근시간 이후 체크 (오후 6시 이후)
+        return currentTime.isAfter(LocalTime.of(18, 0));
+    }
+
+    /**
+     * 지연된 알림 스케줄링
+     */
+    @Async
+    public void scheduleDelayedNotification(Long complaintId, String title, String body, String type) {
+        LocalDateTime now = LocalDateTime.now();
+        int dayOfWeek = now.getDayOfWeek().getValue();
+        
+        String scheduleTime;
+        if (dayOfWeek == 6 || dayOfWeek == 7) {
+            // 주말인 경우: 다음 월요일 오전 9시
+            scheduleTime = "다음 월요일 오전 9시";
+        } else {
+            // 평일 퇴근시간 이후: 다음날 오전 9시
+            scheduleTime = "다음날 오전 9시";
+        }
+        
+        // TODO: 실제 스케줄링 구현 (Quartz, @Scheduled 등 사용)
+        // 현재는 로그만 출력
+        log.info("민원 알림이 {}에 발송 예정 - 민원ID: {}, 타입: {}", scheduleTime, complaintId, type);
+    }
+
+    /**
+     * 모든 관리자에게 알림 발송
+     */
+    private void sendToAllAdmins(Long complaintId, String title, String body) {
+        List<User> admins = userRepository.findByRoleIn(Arrays.asList(Role.ROLE_ADMIN));
+        
+        if (admins.isEmpty()) {
+            log.warn("관리자 사용자가 없습니다.");
+            return;
+        }
+        
+        // 알림 생성
+        Notification notification = Notification.builder()
+                .boardId(complaintId)
+                .title(title)
+                .body(body)
+                .notificationType(NotificationType.COMPLAINT)
+                .build();
+        
+        Notification savedNotification = notificationRepository.save(notification);
+        
+        // 각 관리자에게 알림 발송
+        for (User admin : admins) {
+            // 사용자 알림 생성
+            UserNotification userNotification = UserNotification.builder()
+                    .user(admin)
+                    .notification(savedNotification)
+                    .isRead(false)
+                    .build();
+            
+            userNotificationRepository.save(userNotification);
+            
+            // FCM 푸시 알림 발송
+            try {
+                fcmMessageService.sendNotification(admin, title, body);
+                log.info("관리자 민원 알림 발송 완료 - 관리자: {}, 민원ID: {}", admin.getId(), complaintId);
+            } catch (Exception e) {
+                log.error("관리자 민원 알림 발송 실패 - 관리자: {}, 민원ID: {}", admin.getId(), complaintId, e);
+            }
+        }
+    }
+
+    /**
+     * 상태 변경 메시지 생성
+     */
+    private String getStatusChangeMessage(ComplaintStatus oldStatus, ComplaintStatus newStatus) {
+        if (oldStatus == ComplaintStatus.IN_PROGRESS && newStatus == ComplaintStatus.COMPLETED) {
+            return "민원 처리가 완료되었습니다";
+        } else {
+            return "민원 상태가 " + oldStatus.getDescription() + "에서 " + newStatus.getDescription() + "으로 변경되었습니다";
+        }
+    }
+}

--- a/src/main/java/com/example/appcenter_project/service/notification/ComplaintNotificationService.java
+++ b/src/main/java/com/example/appcenter_project/service/notification/ComplaintNotificationService.java
@@ -1,0 +1,113 @@
+package com.example.appcenter_project.service.notification;
+
+import com.example.appcenter_project.entity.complaint.Complaint;
+import com.example.appcenter_project.entity.notification.Notification;
+import com.example.appcenter_project.entity.notification.UserNotification;
+import com.example.appcenter_project.entity.user.User;
+import com.example.appcenter_project.enums.complaint.ComplaintStatus;
+import com.example.appcenter_project.enums.user.NotificationType;
+import com.example.appcenter_project.exception.CustomException;
+import com.example.appcenter_project.repository.complaint.ComplaintRepository;
+import com.example.appcenter_project.repository.notification.NotificationRepository;
+import com.example.appcenter_project.repository.notification.UserNotificationRepository;
+import com.example.appcenter_project.repository.user.UserRepository;
+import com.example.appcenter_project.service.fcm.FcmMessageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.appcenter_project.exception.ErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class ComplaintNotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserNotificationRepository userNotificationRepository;
+    private final UserRepository userRepository;
+    private final ComplaintRepository complaintRepository;
+    private final FcmMessageService fcmMessageService;
+
+    /**
+     * 민원 답변 시 알림 발송
+     */
+    public void sendNewReplyNotification(Long complaintId) {
+        Complaint complaint = complaintRepository.findById(complaintId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        
+        User complaintUser = complaint.getUser();
+        String title = "생활원 민원";
+        String body = "새로운 답변이 올라왔어요!\n민원 제목: " + complaint.getTitle();
+        
+        // 알림 생성
+        Notification notification = Notification.builder()
+                .boardId(complaintId)
+                .title(title)
+                .body(body)
+                .notificationType(NotificationType.COMPLAINT)
+                .build();
+        
+        Notification savedNotification = notificationRepository.save(notification);
+        
+        // 사용자 알림 생성
+        UserNotification userNotification = UserNotification.builder()
+                .user(complaintUser)
+                .notification(savedNotification)
+                .isRead(false)
+                .build();
+        
+        userNotificationRepository.save(userNotification);
+        
+        // FCM 푸시 알림 발송
+        try {
+            fcmMessageService.sendNotification(complaintUser, title, body);
+            log.info("민원 답변 알림 발송 완료 - 사용자: {}, 민원ID: {}", complaintUser.getId(), complaintId);
+        } catch (Exception e) {
+            log.error("민원 답변 알림 발송 실패 - 사용자: {}, 민원ID: {}", complaintUser.getId(), complaintId, e);
+        }
+    }
+
+    /**
+     * 민원 상태 변경 시 알림 발송
+     */
+    public void sendStatusChangeNotification(Long complaintId, ComplaintStatus newStatus) {
+        Complaint complaint = complaintRepository.findById(complaintId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        
+        User complaintUser = complaint.getUser();
+        String title = "생활원 민원";
+        String body = "접수한 민원의 상태가 " + newStatus.getDescription() + "으로 변경 되었어요!\n민원 제목: " + complaint.getTitle();
+        
+        // 알림 생성
+        Notification notification = Notification.builder()
+                .boardId(complaintId)
+                .title(title)
+                .body(body)
+                .notificationType(NotificationType.COMPLAINT)
+                .build();
+        
+        Notification savedNotification = notificationRepository.save(notification);
+        
+        // 사용자 알림 생성
+        UserNotification userNotification = UserNotification.builder()
+                .user(complaintUser)
+                .notification(savedNotification)
+                .isRead(false)
+                .build();
+        
+        userNotificationRepository.save(userNotification);
+        
+        // FCM 푸시 알림 발송
+        try {
+            fcmMessageService.sendNotification(complaintUser, title, body);
+            log.info("민원 상태 변경 알림 발송 완료 - 사용자: {}, 민원ID: {}, 상태: {}", 
+                    complaintUser.getId(), complaintId, newStatus.getDescription());
+        } catch (Exception e) {
+            log.error("민원 상태 변경 알림 발송 실패 - 사용자: {}, 민원ID: {}, 상태: {}", 
+                    complaintUser.getId(), complaintId, newStatus.getDescription(), e);
+        }
+    }
+}


### PR DESCRIPTION
## 이슈
#349 

## 구현한 기능
1. 새 답변 알림
API: POST /api/admin/complaints/{complaintId}/reply
발송 시점: 관리자가 민원에 답변을 작성할 때
수신자: 해당 민원을 작성한 일반 유저
알림 내용:  제목: "생활원 민원"
  내용: "새로운 답변이 올라왔어요!\n민원 제목: [실제 민원 제목]"
  
2. 상태 변경 알림
API: PUT /api/admin/complaints/{complaintId}/status
발송 시점: 관리자가 민원 상태를 변경할 때
수신자: 해당 민원을 작성한 일반 유저
알림 내용:   제목: "생활원 민원"
  내용: "접수한 민원의 상태가 [상태명]으로 변경 되었어요!\n민원 제목: [실제 민원 제목]"

👨‍💼 관리자용 알림
1. 새 민원 접수 알림
API: POST /api/complaints
발송 시점: 일반 유저가 민원을 접수할 때
수신자: 모든 관리자 (ROLE_ADMIN)
알림 내용:   제목: "생활원 민원"
  내용: "새로운 민원이 접수되었습니다\n민원 제목: [실제 민원 제목]"

2. 민원 처리완료 알림
API: PUT /api/admin/complaints/{complaintId}/status
발송 시점: 민원 상태를 "처리중" → "처리완료"로 변경할 때
수신자: 모든 관리자 (ROLE_ADMIN)
알림 내용:   제목: "생활원 민원"
  내용: "민원 처리가 완료되었습니다\n민원 제목: [실제 민원 제목]"

⏰ 시간 제한 기능
관리자 알림 시간 제한
평일 오전 9시 ~ 오후 6시: 즉시 발송
평일 오후 6시 이후: 다음날 오전 9시에 발송
주말: 다음 월요일 오전 9시에 발송