### PR TITLE
Jimin/complaint csv export 386

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,9 @@ dependencies {
 
 	// aop
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+	// CSV
+	implementation 'com.opencsv:opencsv:5.9'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/appcenter_project/controller/complaint/AdminComplaintApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/complaint/AdminComplaintApiSpecification.java
@@ -1,6 +1,7 @@
 package com.example.appcenter_project.controller.complaint;
 
 import com.example.appcenter_project.dto.request.complaint.RequestComplaintReplyDto;
+import com.example.appcenter_project.dto.request.complaint.RequestComplaintSearchDto;
 import com.example.appcenter_project.dto.request.complaint.RequestComplaintStatusDto;
 import com.example.appcenter_project.dto.response.complaint.ResponseComplaintDetailDto;
 import com.example.appcenter_project.dto.response.complaint.ResponseComplaintListDto;
@@ -174,5 +175,34 @@ public interface AdminComplaintApiSpecification {
             @PathVariable
             @Parameter(description = "담당자명", required = true, example = "김관리")
             String officer
+    );
+
+    @Operation(
+            summary = "민원 목록 CSV 다운로드 (전체)",
+            description = "등록된 모든 민원을 CSV 파일로 다운로드합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "CSV 다운로드 성공",
+                            content = @Content(mediaType = "application/octet-stream")
+                    )
+            }
+    )
+    ResponseEntity<byte[]> exportComplaintsToCsv();
+
+    @Operation(
+            summary = "민원 목록 CSV 다운로드 (필터링)",
+            description = "검색 조건에 맞는 민원을 CSV 파일로 다운로드합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "CSV 다운로드 성공",
+                            content = @Content(mediaType = "application/octet-stream")
+                    )
+            }
+    )
+    ResponseEntity<byte[]> exportComplaintsToCsvWithFilter(
+            @Parameter(description = "검색 조건", required = true)
+            RequestComplaintSearchDto dto
     );
 }

--- a/src/main/java/com/example/appcenter_project/controller/complaint/AdminComplaintController.java
+++ b/src/main/java/com/example/appcenter_project/controller/complaint/AdminComplaintController.java
@@ -13,12 +13,18 @@ import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
@@ -104,6 +110,44 @@ public class AdminComplaintController implements AdminComplaintApiSpecification 
         return ResponseEntity.ok(
                 complaintService.searchComplaints(null, dto)
         );
+    }
+
+    // 민원 목록 CSV 다운로드 (전체)
+    @GetMapping("/export/csv")
+    public ResponseEntity<byte[]> exportComplaintsToCsv() {
+        byte[] csvData = complaintService.exportComplaintsToCsv();
+        
+        String fileName = "민원목록_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")) + ".csv";
+        String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8);
+        
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.valueOf("text/csv; charset=UTF-8"));
+        headers.set("Content-Disposition", "attachment; filename=\"" + encodedFileName + "\"; filename*=UTF-8''" + encodedFileName);
+        headers.setContentLength(csvData.length);
+        
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(csvData);
+    }
+
+    // 민원 목록 CSV 다운로드 (필터링된)
+    @GetMapping("/export/csv/search")
+    public ResponseEntity<byte[]> exportComplaintsToCsvWithFilter(
+            @ModelAttribute RequestComplaintSearchDto dto
+    ) {
+        byte[] csvData = complaintService.exportComplaintsToCsv(dto);
+        
+        String fileName = "민원목록_필터링_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")) + ".csv";
+        String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8);
+        
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.valueOf("text/csv; charset=UTF-8"));
+        headers.set("Content-Disposition", "attachment; filename=\"" + encodedFileName + "\"; filename*=UTF-8''" + encodedFileName);
+        headers.setContentLength(csvData.length);
+        
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(csvData);
     }
 
 

--- a/src/main/java/com/example/appcenter_project/dto/response/complaint/ResponseComplaintCsvDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/complaint/ResponseComplaintCsvDto.java
@@ -1,0 +1,31 @@
+package com.example.appcenter_project.dto.response.complaint;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ResponseComplaintCsvDto {
+    private Long id;
+    private String date;
+    private String type;
+    private String title;
+    private String content;
+    private String status;
+    private String officer;
+    private String dormType;
+    private String building;
+    private String floor;
+    private String roomNumber;
+    private String bedNumber;
+    private String userName;
+    private String userEmail;
+    private String userPhone;
+    private String replyTitle;
+    private String replyContent;
+    private String responderName;
+    private String replyDate;
+    private boolean isPrivacyAgreed;
+}

--- a/src/main/java/com/example/appcenter_project/service/complaint/ComplaintService.java
+++ b/src/main/java/com/example/appcenter_project/service/complaint/ComplaintService.java
@@ -23,6 +23,8 @@ import com.example.appcenter_project.repository.complaint.ComplaintSpecification
 import com.example.appcenter_project.repository.image.ImageRepository;
 import com.example.appcenter_project.repository.user.UserRepository;
 import com.example.appcenter_project.service.notification.AdminComplaintNotificationService;
+import com.example.appcenter_project.dto.response.complaint.ResponseComplaintCsvDto;
+import com.example.appcenter_project.utils.CsvUtils;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -56,6 +58,7 @@ public class ComplaintService {
     private final AttachedFileRepository attachedFileRepository;
     private final AdminComplaintNotificationService adminComplaintNotificationService;
     private final ImageService imageService;
+    private final CsvUtils csvUtils;
 
     // 민원 등록
     public ResponseComplaintDto createComplaint(Long userId, RequestComplaintDto dto, List<MultipartFile> images) {
@@ -374,6 +377,74 @@ public class ComplaintService {
                         .bedNumber(c.getBedNumber())
                         .build())
                 .toList();
+    }
+
+    // 민원 목록을 CSV로 변환 (전체 조회)
+    public byte[] exportComplaintsToCsv() {
+        List<Complaint> complaints = complaintRepository.findAllByOrderByCreatedDateDesc();
+        List<ResponseComplaintCsvDto> csvData = complaints.stream()
+                .map(this::convertToCsvDto)
+                .collect(Collectors.toList());
+        
+        return csvUtils.generateComplaintCsv(csvData);
+    }
+
+    // 민원 목록을 CSV로 변환 (필터링된 조회)
+    public byte[] exportComplaintsToCsv(RequestComplaintSearchDto searchDto) {
+        Specification<Complaint> spec = Specification
+                .where(ComplaintSpecification.hasDormType(searchDto.getDormType()))
+                .and(ComplaintSpecification.hasOfficer(searchDto.getOfficer()))
+                .and(ComplaintSpecification.hasStatus(searchDto.getStatus()))
+                .and(ComplaintSpecification.hasKeyword(searchDto.getKeyword()))
+                .and(ComplaintSpecification.hasType(searchDto.getType()))
+                .and(ComplaintSpecification.hasBuilding(
+                        searchDto.getBuilding() != null && !searchDto.getBuilding().isBlank()
+                                ? DormBuilding.valueOf(searchDto.getBuilding())
+                                : null
+                ))
+                .and(ComplaintSpecification.hasFloor(searchDto.getFloor()))
+                .and(ComplaintSpecification.hasRoomNumber(searchDto.getRoomNumber()))
+                .and(ComplaintSpecification.hasBedNumber(searchDto.getBedNumber()));
+
+        List<Complaint> complaints = complaintRepository.findAll(spec);
+        List<ResponseComplaintCsvDto> csvData = complaints.stream()
+                .map(this::convertToCsvDto)
+                .collect(Collectors.toList());
+        
+        return csvUtils.generateComplaintCsv(csvData);
+    }
+
+    // Complaint 엔티티를 CSV DTO로 변환
+    private ResponseComplaintCsvDto convertToCsvDto(Complaint complaint) {
+        User user = complaint.getUser();
+        ComplaintReply reply = complaint.getReply();
+        
+        return ResponseComplaintCsvDto.builder()
+                .id(complaint.getId())
+                .date(complaint.getCreatedDate() != null 
+                    ? complaint.getCreatedDate().toLocalDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
+                    : null)
+                .type(complaint.getType() != null ? complaint.getType().toValue() : null)
+                .title(complaint.getTitle())
+                .content(complaint.getContent())
+                .status(complaint.getStatus() != null ? complaint.getStatus().toValue() : null)
+                .officer(complaint.getOfficer())
+                .dormType(complaint.getDormType() != null ? complaint.getDormType().toValue() : null)
+                .building(complaint.getBuilding() != null ? complaint.getBuilding().toValue() : null)
+                .floor(complaint.getFloor())
+                .roomNumber(complaint.getRoomNumber())
+                .bedNumber(complaint.getBedNumber())
+                .userName(user != null ? user.getName() : null)
+                .userEmail(null) // User 엔티티에 email 필드가 없음
+                .userPhone(null) // User 엔티티에 phone 필드가 없음
+                .replyTitle(reply != null ? reply.getReplyTitle() : null)
+                .replyContent(reply != null ? reply.getReplyContent() : null)
+                .responderName(reply != null ? reply.getResponderName() : null)
+                .replyDate(reply != null && reply.getCreatedDate() != null 
+                    ? reply.getCreatedDate().toLocalDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
+                    : null)
+                .isPrivacyAgreed(complaint.isPrivacyAgreed())
+                .build();
     }
 
 

--- a/src/main/java/com/example/appcenter_project/utils/CsvUtils.java
+++ b/src/main/java/com/example/appcenter_project/utils/CsvUtils.java
@@ -1,0 +1,70 @@
+package com.example.appcenter_project.utils;
+
+import com.example.appcenter_project.dto.response.complaint.ResponseComplaintCsvDto;
+import com.opencsv.CSVWriter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Slf4j
+@Component
+public class CsvUtils {
+
+    public byte[] generateComplaintCsv(List<ResponseComplaintCsvDto> complaints) {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+             OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
+             CSVWriter csvWriter = new CSVWriter(writer, ',', '"', '"', "\r\n")) {
+
+            // BOM 추가 (한글 Excel 호환성을 위해)
+            outputStream.write(0xEF);
+            outputStream.write(0xBB);
+            outputStream.write(0xBF);
+
+            // CSV 헤더 작성 (민원 조회 필드와 민원번호)
+            String[] header = {
+                "민원번호", "날짜", "유형", "제목", "현황", "담당자", 
+                "기숙사", "호실정보"
+            };
+            csvWriter.writeNext(header);
+
+            // 데이터 행 작성 (민원 조회 필드와 민원번호)
+            for (ResponseComplaintCsvDto complaint : complaints) {
+                // 호실정보를 "동 호수 침대번호" 형태로 조합
+                String roomInfo = "";
+                if (complaint.getBuilding() != null) {
+                    roomInfo += complaint.getBuilding();
+                }
+                if (complaint.getRoomNumber() != null) {
+                    roomInfo += " " + complaint.getRoomNumber();
+                }
+                if (complaint.getBedNumber() != null) {
+                    roomInfo += " " + complaint.getBedNumber();
+                }
+                
+                String[] row = {
+                    complaint.getId() != null ? String.valueOf(complaint.getId()) : "",
+                    complaint.getDate() != null ? complaint.getDate() : "",
+                    complaint.getType() != null ? complaint.getType() : "",
+                    complaint.getTitle() != null ? complaint.getTitle() : "",
+                    complaint.getStatus() != null ? complaint.getStatus() : "",
+                    complaint.getOfficer() != null ? complaint.getOfficer() : "",
+                    complaint.getDormType() != null ? complaint.getDormType() : "",
+                    roomInfo.trim()
+                };
+                csvWriter.writeNext(row);
+            }
+
+            csvWriter.flush();
+            return outputStream.toByteArray();
+
+        } catch (IOException e) {
+            log.error("CSV 생성 중 오류 발생", e);
+            throw new RuntimeException("CSV 파일 생성에 실패했습니다.", e);
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
#386 

## 구현한 내용
- CSV 다운로드 DTO 및 유틸리티 클래스 추가
- 민원 서비스에 CSV 생성 메서드 추가
- 관리자 컨트롤러에 CSV 다운로드 엔드포인트 추가
- OpenCSV 의존성 추가
-  API 스펙에 CSV 엔드포인트 문서화

## 관련 이미지

- 민원 목록 csv 다운로드(전체)
<img width="1749" height="1373" alt="image" src="https://github.com/user-attachments/assets/ca6298f2-469d-4240-97c1-d4ffbfbc7782" />

- 민원 목록 csv 다운로드(필터)
<img width="1758" height="1821" alt="image" src="https://github.com/user-attachments/assets/ad0795c4-f790-4b5b-99a1-66a7b9e43e29" />

- 엑셀 결과
<img width="1293" height="396" alt="image" src="https://github.com/user-attachments/assets/0f55009e-d5e1-495f-a5d2-7619ed0e3d01" />
