### PR TITLE
Jimin/add survey status field 437

### DIFF
--- a/src/main/java/com/example/appcenter_project/controller/survey/SurveyApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/survey/SurveyApiSpecification.java
@@ -100,7 +100,7 @@ public interface SurveyApiSpecification {
 
     @Operation(
             summary = "모든 설문 조회",
-            description = "등록된 모든 설문 목록을 조회합니다. 종료일이 지난 설문은 자동으로 종료 처리됩니다.",
+            description = "등록된 모든 설문 목록을 조회합니다. 종료일이 지난 설문은 자동으로 종료 처리됩니다. 로그인한 사용자의 경우 각 설문의 제출 여부(hasSubmitted)를 포함하여 반환합니다.",
             responses = {
                     @ApiResponse(
                             responseCode = "200",

--- a/src/main/java/com/example/appcenter_project/dto/response/survey/ResponseSurveyDetailDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/survey/ResponseSurveyDetailDto.java
@@ -1,6 +1,7 @@
 package com.example.appcenter_project.dto.response.survey;
 
 import com.example.appcenter_project.entity.survey.Survey;
+import com.example.appcenter_project.enums.survey.SurveyStatus;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -20,7 +21,7 @@ public class ResponseSurveyDetailDto {
     private String creatorName;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-    private boolean isClosed;
+    private SurveyStatus status;
     private LocalDateTime createdDate;
     private Integer totalResponses;
 
@@ -35,7 +36,7 @@ public class ResponseSurveyDetailDto {
                 .creatorName(survey.getCreator().getName())
                 .startDate(survey.getStartDate())
                 .endDate(survey.getEndDate())
-                .isClosed(survey.isClosed())
+                .status(survey.getStatus())
                 .createdDate(survey.getCreatedDate())
                 .totalResponses(survey.getResponses().size())
                 .questions(survey.getQuestions().stream()

--- a/src/main/java/com/example/appcenter_project/dto/response/survey/ResponseSurveyDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/survey/ResponseSurveyDto.java
@@ -1,6 +1,8 @@
 package com.example.appcenter_project.dto.response.survey;
 
 import com.example.appcenter_project.entity.survey.Survey;
+import com.example.appcenter_project.enums.survey.SurveyStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -17,9 +19,14 @@ public class ResponseSurveyDto {
     private String creatorName;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-    private boolean isClosed;
     private LocalDateTime createdDate;
     private Integer totalResponses;
+    
+    @JsonProperty("hasSubmitted")
+    @Builder.Default
+    private boolean hasSubmitted = false;  // 사용자 제출 여부
+    
+    private SurveyStatus status;  // 설문 진행 상태 (진행전/진행중/마감)
 
     public static ResponseSurveyDto entityToDto(Survey survey) {
         return ResponseSurveyDto.builder()
@@ -29,9 +36,25 @@ public class ResponseSurveyDto {
                 .creatorName(survey.getCreator().getName())
                 .startDate(survey.getStartDate())
                 .endDate(survey.getEndDate())
-                .isClosed(survey.isClosed())
                 .createdDate(survey.getCreatedDate())
                 .totalResponses(survey.getResponses().size())
+                .hasSubmitted(false)
+                .status(survey.getStatus())
+                .build();
+    }
+    
+    public static ResponseSurveyDto entityToDto(Survey survey, boolean hasSubmitted) {
+        return ResponseSurveyDto.builder()
+                .id(survey.getId())
+                .title(survey.getTitle())
+                .description(survey.getDescription())
+                .creatorName(survey.getCreator().getName())
+                .startDate(survey.getStartDate())
+                .endDate(survey.getEndDate())
+                .createdDate(survey.getCreatedDate())
+                .totalResponses(survey.getResponses().size())
+                .hasSubmitted(hasSubmitted)
+                .status(survey.getStatus())
                 .build();
     }
 }

--- a/src/main/java/com/example/appcenter_project/dto/response/survey/ResponseSurveyDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/survey/ResponseSurveyDto.java
@@ -56,7 +56,6 @@ public class ResponseSurveyDto {
                 .totalResponses(survey.getResponses().size())
                 .hasSubmitted(hasSubmitted)
                 .status(survey.getStatus())
-                .isClosed(survey.isClosed())
                 .createdDate(survey.getCreatedDate())
                 .totalResponses(survey.getResponses().size())
                 .hasSubmitted(hasSubmitted)

--- a/src/main/java/com/example/appcenter_project/enums/survey/SurveyStatus.java
+++ b/src/main/java/com/example/appcenter_project/enums/survey/SurveyStatus.java
@@ -1,0 +1,32 @@
+package com.example.appcenter_project.enums.survey;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SurveyStatus {
+    BEFORE("진행전"),      // 시작일 이전
+    PROCEEDING("진행중"),  // 진행 중
+    CLOSED("마감");        // 종료됨
+    
+    private final String description;
+    
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static SurveyStatus from(String value) {
+        for (SurveyStatus status : SurveyStatus.values()) {
+            if (status.getDescription().equals(value) || status.name().equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Invalid SurveyStatus: " + value);
+    }
+    
+    @JsonValue
+    public String toValue() {
+        return this.description;
+    }
+}
+

--- a/src/main/java/com/example/appcenter_project/repository/survey/SurveyRepository.java
+++ b/src/main/java/com/example/appcenter_project/repository/survey/SurveyRepository.java
@@ -13,8 +13,8 @@ public interface SurveyRepository extends JpaRepository<Survey, Long> {
 
     List<Survey> findByCreatorId(Long creatorId);
 
-    @Query("SELECT s FROM Survey s WHERE s.isClosed = false AND s.startDate <= :now AND s.endDate >= :now")
-    List<Survey> findActiveSurveys(@Param("now") LocalDateTime now);
+    @Query("SELECT s FROM Survey s WHERE s.status = 'PROCEEDING'")
+    List<Survey> findActiveSurveys();
 
     @Query("SELECT DISTINCT s FROM Survey s LEFT JOIN FETCH s.questions WHERE s.id = :id")
     Optional<Survey> findByIdWithQuestions(@Param("id") Long id);


### PR DESCRIPTION
## 관련 이슈
#437 

## 구현할 내용
- 설문 상태 관리를 is_closed boolean에서 SurveyStatus enum(BEFORE, PROCEEDING, CLOSED)으로 전환
- 관리자가 수동 종료한 설문은 updateStatus() 호출 시 날짜와 무관하게 CLOSED 상태를 유지
- Survey 엔티티에 status 필드 추가 (SurveyStatus enum 타입)
- ResponseSurveyDto, ResponseSurveyDetailDto에 status 필드 추가

## 관련 사진
- 시간이 시작하기 전
<img width="1264" height="1225" alt="image" src="https://github.com/user-attachments/assets/eef35348-4495-4497-b84c-6c9e91b08388" />

-시간이 시작했을 때
<img width="1238" height="1253" alt="image" src="https://github.com/user-attachments/assets/52973f2d-5b5a-4069-97b6-242fd0e62c67" />

-시간이 종료되거나 관리자가 종료했을 때
<img width="1227" height="1245" alt="image" src="https://github.com/user-attachments/assets/886c2bce-d6bd-48fa-99ca-ae6ae07d65fa" />
