### PR TITLE
feat: FCM 알림 발송 통계 조회 API 추가 #553

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -6,3 +6,16 @@
 | 날짜 | Issue | 제목 | 브랜치 | 설명 |
 |------|-------|------|--------|------|
 | 2026-03-28 | [#551](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/551) | Claude Code 프로젝트 설정 | teach/chore/claude-551 | .claude 폴더 구성 |
+| 2026-03-29 | [#553](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/553) | FCM 알림 통계 조회 API | teach/feat/fcm-stats-553 | FCM 성공/실패 Redis 통계 ADMIN 조회 |
+
+## 현재 작업 이슈
+
+- **번호**: #553
+- **제목**: [feat] FCM 알림 통계 조회 API
+- **브랜치**: teach/feat/fcm-stats-553
+- **작업 목록**:
+  - [ ] ResponseFcmStatsDto 작성 (date, successCount, failCount)
+  - [ ] FcmMessageService에 오늘 날짜 Redis 통계 조회 메서드 추가
+  - [ ] FcmController에 GET /fcm/stats 엔드포인트 추가 (ADMIN 권한)
+  - [ ] FcmApiSpecification에 Swagger 명세 추가
+  - [ ] SecurityConfig에 ADMIN 권한 설정 확인

--- a/src/main/java/com/example/appcenter_project/domain/fcm/controller/FcmApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/domain/fcm/controller/FcmApiSpecification.java
@@ -3,6 +3,7 @@ package com.example.appcenter_project.domain.fcm.controller;
 import com.example.appcenter_project.domain.fcm.dto.request.RequestFcmMessageDto;
 import com.example.appcenter_project.domain.fcm.dto.request.RequestFcmTokenDto;
 import com.example.appcenter_project.domain.fcm.dto.response.ResponseFcmMessageDto;
+import com.example.appcenter_project.domain.fcm.dto.response.ResponseFcmStatsDto;
 import com.example.appcenter_project.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -29,6 +30,21 @@ public interface FcmApiSpecification {
             @RequestBody @Parameter(description = "FCM 토큰 요청 DTO", required = true)
             RequestFcmTokenDto requestDto
     );
+
+    @Operation(
+            summary = "FCM 발송 통계 조회 (ADMIN)",
+            description = "오늘 날짜 기준 FCM 알림 발송 성공/실패 건수를 조회합니다. Redis TTL 24시간 기준이므로 당일 데이터만 제공됩니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "통계 조회 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseFcmStatsDto.class))
+                    ),
+                    @ApiResponse(responseCode = "403", description = "ADMIN 권한 없음", content = @Content())
+            }
+    )
+    ResponseEntity<ResponseFcmStatsDto> getFcmStats();
 
     @Operation(
             summary = "전체 사용자에게 FCM 알림 전송",

--- a/src/main/java/com/example/appcenter_project/domain/fcm/controller/FcmController.java
+++ b/src/main/java/com/example/appcenter_project/domain/fcm/controller/FcmController.java
@@ -1,8 +1,10 @@
 package com.example.appcenter_project.domain.fcm.controller;
 
+import com.example.appcenter_project.common.metrics.annotation.TrackApi;
 import com.example.appcenter_project.domain.fcm.dto.request.RequestFcmMessageDto;
 import com.example.appcenter_project.domain.fcm.dto.request.RequestFcmTokenDto;
 import com.example.appcenter_project.domain.fcm.dto.response.ResponseFcmMessageDto;
+import com.example.appcenter_project.domain.fcm.dto.response.ResponseFcmStatsDto;
 import com.example.appcenter_project.global.security.CustomUserDetails;
 import com.example.appcenter_project.domain.fcm.service.FcmMessageService;
 import com.example.appcenter_project.domain.fcm.service.FcmTokenService;
@@ -26,6 +28,12 @@ public class FcmController implements FcmApiSpecification{
     ) {
         fcmTokenService.saveToken(userDetails, requestDto.getFcmToken());
         return ResponseEntity.ok().build();
+    }
+
+    @TrackApi
+    @GetMapping("/stats")
+    public ResponseEntity<ResponseFcmStatsDto> getFcmStats() {
+        return ResponseEntity.ok(fcmMessageService.getFcmStats());
     }
 
     // 전체 사용자에게 알림 전송 (user_id가 NULL인 토큰도 포함)

--- a/src/main/java/com/example/appcenter_project/domain/fcm/dto/response/ResponseFcmStatsDto.java
+++ b/src/main/java/com/example/appcenter_project/domain/fcm/dto/response/ResponseFcmStatsDto.java
@@ -1,0 +1,12 @@
+package com.example.appcenter_project.domain.fcm.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResponseFcmStatsDto {
+    private String date;
+    private long successCount;
+    private long failCount;
+}

--- a/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmMessageService.java
+++ b/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmMessageService.java
@@ -1,6 +1,7 @@
 package com.example.appcenter_project.domain.fcm.service;
 
 import com.example.appcenter_project.domain.fcm.dto.response.ResponseFcmMessageDto;
+import com.example.appcenter_project.domain.fcm.dto.response.ResponseFcmStatsDto;
 import com.example.appcenter_project.domain.fcm.entity.FcmToken;
 import com.example.appcenter_project.domain.user.entity.User;
 import com.example.appcenter_project.domain.user.enums.DormType;
@@ -223,6 +224,25 @@ public class FcmMessageService {
         }
 
         log.info("      🚀 sendMessageToUser 종료 (User ID: {}, 총 {}개 토큰 처리)", user.getId(), tokenIndex);
+    }
+
+    @Transactional(readOnly = true)
+    public ResponseFcmStatsDto getFcmStats() {
+        LocalDate today = LocalDate.now();
+        String successKey = FCM_SUCCESS_KEY_PREFIX + today;
+        String failKey = FCM_FAIL_KEY_PREFIX + today;
+
+        Object successVal = redisTemplate.opsForValue().get(successKey);
+        Object failVal = redisTemplate.opsForValue().get(failKey);
+
+        long successCount = successVal != null ? Long.parseLong(successVal.toString()) : 0L;
+        long failCount = failVal != null ? Long.parseLong(failVal.toString()) : 0L;
+
+        return ResponseFcmStatsDto.builder()
+                .date(today.toString())
+                .successCount(successCount)
+                .failCount(failCount)
+                .build();
     }
 
     private void recordFcmSuccess() {

--- a/src/main/java/com/example/appcenter_project/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/appcenter_project/global/config/SecurityConfig.java
@@ -143,7 +143,8 @@ public class SecurityConfig {
                         /** 사용자 알림 **/
                         .requestMatchers("/user-notifications/**").authenticated()
 
-                        /** FCM 토큰 **/
+                        /** FCM **/
+                        .requestMatchers(GET, "/fcm/stats").hasRole("ADMIN")
                         .requestMatchers("/fcm/token/**").permitAll()
 
                         /** 쿠폰 **/


### PR DESCRIPTION
## 개요
FCM 알림 발송 결과(성공/실패)가 Redis에 저장되고 있었으나 이를 조회할 수 있는 API가 없었습니다. ADMIN이 오늘 날짜 기준 발송 현황을 확인할 수 있도록 GET /fcm/stats 엔드포인트를 추가합니다.

## 변경 사항
- [DTO] ResponseFcmStatsDto 추가 (date, successCount, failCount)
- [Service] FcmMessageService.getFcmStats() - Redis에서 오늘 통계 조회 메서드 추가
- [API] GET /fcm/stats - ADMIN 전용 FCM 발송 통계 조회 엔드포인트 추가 (c943b99)
- [Swagger] FcmApiSpecification에 /fcm/stats 명세 추가
- [설정] SecurityConfig에 GET /fcm/stats ADMIN 권한 설정

## 테스트
- [ ] 로컬 빌드 확인 (`./gradlew build`)
- [ ] ADMIN 계정으로 GET /fcm/stats 호출 시 오늘 날짜 성공/실패 카운트 정상 반환
- [ ] 일반 USER 계정으로 호출 시 403 반환

closes #553