### PR TITLE
fix: 체팅방 입장 중 수신자 FCM 알림 전송 차단 #555

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -7,6 +7,15 @@
 |------|-------|------|--------|------|
 | 2026-03-28 | [#551](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/551) | Claude Code 프로젝트 설정 | teach/chore/claude-551 | .claude 폴더 구성 |
 | 2026-03-29 | [#553](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/553) | FCM 알림 통계 조회 API | teach/feat/fcm-stats-553 | FCM 성공/실패 Redis 통계 ADMIN 조회 |
+| 2026-03-29 | [#555](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/555) | 룸메이트 채팅방 입장 중 알림 차단 | teach/fix/roommate-chat-notification-555 | 채팅방 입장 중 알림 DB+FCM 생략 |
+
+## 현재 작업 이슈
+
+- **번호**: #555
+- **제목**: [fix] 룸메이트 채팅방 입장 중 알림 차단
+- **브랜치**: teach/fix/roommate-chat-notification-555
+- **작업 목록**:
+  - [ ] RoommateChattingChatService.sendChat()에서 수신자가 채팅방 입장 중이면 sendChatNotification() 호출 스킵 (DB 저장 + FCM 모두 생략)
 
 ## 완료된 이슈
 

--- a/src/main/java/com/example/appcenter_project/domain/roommate/service/RoommateChattingChatService.java
+++ b/src/main/java/com/example/appcenter_project/domain/roommate/service/RoommateChattingChatService.java
@@ -101,7 +101,9 @@ public class RoommateChattingChatService {
             messagingTemplate.convertAndSend(readDestination, readIds);
         }
 
-        sendChatNotification(sender, receiver, room.getId(), chat.getContent());
+        if (!isReceiverOnline) {
+            sendChatNotification(sender, receiver, room.getId(), chat.getContent());
+        }
 
         return responseDto;
     }


### PR DESCRIPTION
## 개요
룸메이트 체팅방에 현재 입장해 있는 수신자에게도 FCM 알림이 발송되는 문제가 있었습니다.
수신자가 체팅방에 접속 중일 때는 실시간으로 메시지를 확인하고 있으므로
Notification 저장 및 FCM 전송을 모두 생략합니다.

## 변경 사항
- [Service] RoommateChattingChatService.sendChat()에서 isReceiverOnline 체크 후
  수신자 입장 중이면 sendChatNotification() 호출 스킵 (ff340bd)

## 테스트
- [ ] 로컈 빌드 확인 (`./gradlew build`)
- [ ] 체팅방 입장 중인 수신자에게 메시지 전송 시 FCM 알림 미발송 확인
- [ ] 체팅방 미입장 수신자에게 메시지 전송 시 FCM 알림 정상 발송 확인

closes #555