### PR TITLE
refactor: FCM 알림 다중 기기 지원 및 비동기 처리 개선 #557

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -8,15 +8,19 @@
 | 2026-03-28 | [#551](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/551) | Claude Code 프로젝트 설정 | teach/chore/claude-551 | .claude 폴더 구성 |
 | 2026-03-29 | [#553](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/553) | FCM 알림 통계 조회 API | teach/feat/fcm-stats-553 | FCM 성공/실패 Redis 통계 ADMIN 조회 |
 | 2026-03-29 | [#555](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/555) | 룸메이트 채팅방 입장 중 알림 차단 | teach/fix/roommate-chat-notification-555 | 채팅방 입장 중 알림 DB+FCM 생략 |
+| 2026-03-29 | [#557](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/557) | FCM 알림 다중 기기 지원 및 비동기 처리 개선 | teach/refactor/fcm-notification-improvement-557 | 다중 기기 전송, 실패 토큰 정리, @Async 처리 |
 
 ## 현재 작업 이슈
 
-- **번호**: #555
-- **제목**: [fix] 룸메이트 채팅방 입장 중 알림 차단
-- **브랜치**: teach/fix/roommate-chat-notification-555
+- **번호**: #557
+- **제목**: [refactor] FCM 알림 다중 기기 지원 및 비동기 처리 개선
+- **브랜치**: teach/refactor/fcm-notification-improvement-557
 - **작업 목록**:
-  - [ ] RoommateChattingChatService.sendChat()에서 수신자가 채팅방 입장 중이면 sendChatNotification() 호출 스킵 (DB 저장 + FCM 모두 생략)
+  - [ ] sendNotification()에서 첫 번째 성공 후 return 제거 → 모든 토큰에 전송 (다중 기기 지원)
+  - [ ] 각 토큰 전송 실패 시 즉시 토큰 삭제 보장 (성공 여부와 무관하게 실패 토큰 정리)
+  - [ ] FCM 전송 메서드를 @Async로 비동기 처리
 
 ## 완료된 이슈
 
 - [x] #553 [feat] FCM 알림 통계 조회 API → PR #554 merged
+- [x] #555 [fix] 룸메이트 채팅방 입장 중 알림 차단 → PR #556 merged

--- a/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmMessageService.java
+++ b/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmMessageService.java
@@ -19,6 +19,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,8 +38,8 @@ public class FcmMessageService {
     private final RedisTemplate<String, Object> redisTemplate;
 
     // todo User user
-    public String sendNotification(User user, String title, String body) {
-        String lastResponse = null;
+    @Async("fcmExecutor")
+    public void sendNotification(User user, String title, String body) {
         for (FcmToken fcmToken : user.getFcmTokenList()) {
             String targetToken = fcmToken.getToken();
 
@@ -56,14 +57,12 @@ public class FcmMessageService {
                 String response = FirebaseMessaging.getInstance().send(message);
                 log.info("Successfully sent FCM message: {}", response);
                 recordFcmSuccess();
-                lastResponse = response;
             } catch (Exception e) {
                 log.error("Error sending FCM message", e);
                 fcmTokenRepository.deleteByToken(targetToken);
                 recordFcmFail();
             }
         }
-        return lastResponse;
     }
 
     // 추가: 전체 사용자(회원 + 비회원)에게 전송
@@ -106,8 +105,8 @@ public class FcmMessageService {
                 .build();
     }
 
-    public String sendNotificationDormitoryPerson(String title, String body) {
-        String lastResponse = null;
+    @Async("fcmExecutor")
+    public void sendNotificationDormitoryPerson(String title, String body) {
         for (User user : userRepository.findByDormTypeNot(DormType.NONE)) {
             if (user.getReceiveNotificationTypes().contains(NotificationType.DORMITORY)) {
                 for (FcmToken fcmToken : user.getFcmTokenList()) {
@@ -127,7 +126,6 @@ public class FcmMessageService {
                         String response = FirebaseMessaging.getInstance().send(message);
                         log.info("Successfully sent FCM message: {}", response);
                         recordFcmSuccess();
-                        lastResponse = response;
                     } catch (Exception e) {
                         log.error("Error sending FCM message", e);
                         fcmTokenRepository.deleteByToken(targetToken);
@@ -136,9 +134,9 @@ public class FcmMessageService {
                 }
             }
         }
-        return lastResponse;
     }
 
+    @Async("fcmExecutor")
     public void sendGroupOrderNotification(User user, String title, String body) {
         if (!user.getReceiveNotificationTypes().contains(NotificationType.GROUP_ORDER)) {
             return;
@@ -147,6 +145,7 @@ public class FcmMessageService {
         sendMessageToUser(user, title, body);
     }
 
+    @Async("fcmExecutor")
     public void sendDormitoryNotification(User user, String title, String body) {
         if (!user.getReceiveNotificationTypes().contains(NotificationType.DORMITORY)) {
             return;
@@ -156,6 +155,7 @@ public class FcmMessageService {
 
     }
 
+    @Async("fcmExecutor")
     public void sendUnidormNotification(User user, String title, String body) {
         if (!user.getReceiveNotificationTypes().contains(NotificationType.UNI_DORM)) {
             return;
@@ -256,6 +256,7 @@ public class FcmMessageService {
         redisTemplate.expire(key, Duration.ofHours(24));
     }
 
+    @Async("fcmExecutor")
     public void sendSupporterNotification(User user, String title, String body) {
         if (!user.getReceiveNotificationTypes().contains(NotificationType.SUPPORTERS)) {
             return;
@@ -264,6 +265,7 @@ public class FcmMessageService {
         sendMessageToUser(user, title, body);
     }
 
+    @Async("fcmExecutor")
     public void sendUnidormAnnouncementNotification(User user, String title, String body) {
         if (!user.getReceiveNotificationTypes().contains(NotificationType.UNI_DORM)) {
             return;

--- a/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmMessageService.java
+++ b/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmMessageService.java
@@ -38,6 +38,7 @@ public class FcmMessageService {
 
     // todo User user
     public String sendNotification(User user, String title, String body) {
+        String lastResponse = null;
         for (FcmToken fcmToken : user.getFcmTokenList()) {
             String targetToken = fcmToken.getToken();
 
@@ -55,15 +56,14 @@ public class FcmMessageService {
                 String response = FirebaseMessaging.getInstance().send(message);
                 log.info("Successfully sent FCM message: {}", response);
                 recordFcmSuccess();
-                return response; // 메시지 ID 반환
+                lastResponse = response;
             } catch (Exception e) {
                 log.error("Error sending FCM message", e);
                 fcmTokenRepository.deleteByToken(targetToken);
                 recordFcmFail();
             }
         }
-        // todo 임시로 null
-        return null;
+        return lastResponse;
     }
 
     // 추가: 전체 사용자(회원 + 비회원)에게 전송
@@ -107,6 +107,7 @@ public class FcmMessageService {
     }
 
     public String sendNotificationDormitoryPerson(String title, String body) {
+        String lastResponse = null;
         for (User user : userRepository.findByDormTypeNot(DormType.NONE)) {
             if (user.getReceiveNotificationTypes().contains(NotificationType.DORMITORY)) {
                 for (FcmToken fcmToken : user.getFcmTokenList()) {
@@ -126,7 +127,7 @@ public class FcmMessageService {
                         String response = FirebaseMessaging.getInstance().send(message);
                         log.info("Successfully sent FCM message: {}", response);
                         recordFcmSuccess();
-                        return response; // 메시지 ID 반환
+                        lastResponse = response;
                     } catch (Exception e) {
                         log.error("Error sending FCM message", e);
                         fcmTokenRepository.deleteByToken(targetToken);
@@ -135,9 +136,7 @@ public class FcmMessageService {
                 }
             }
         }
-
-        // todo 임시로 null
-        return null;
+        return lastResponse;
     }
 
     public void sendGroupOrderNotification(User user, String title, String body) {

--- a/src/main/java/com/example/appcenter_project/global/config/AsyncConfig.java
+++ b/src/main/java/com/example/appcenter_project/global/config/AsyncConfig.java
@@ -21,4 +21,15 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(name = "fcmExecutor")
+    public Executor fcmExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("FCM-");
+        executor.initialize();
+        return executor;
+    }
 }


### PR DESCRIPTION
## 개요
FCM 알림 전송 시 다중 기기 지원 부재, 동기 전송 방식, 유효하지 않은 토큰 미삭제 문제를 개선합니다.
sendNotification()이 첫 번째 성공 후 return하여 나머지 토큰에 전송되지 않던 버그를 수정하고,
FCM 전송 메서드를 @Async로 처리하여 API 응답 지연을 방지합니다.

## 변경 사항
- [Service] sendNotification(), sendNotificationDormitoryPerson() early return 제거 → 모든 토큰 순회 (2aac126)
- [Service] 전송 실패 토큰 즉시 삭제 보장 (early return 제거로 자동 해결)
- [Service] FCM 전송 메서드 전체에 @Async("fcmExecutor") 적용, void 반환 (1f143a8)
- [설정] AsyncConfig에 FCM 전용 스레드풀 fcmExecutor 추가 (corePool: 2, maxPool: 10) (1f143a8)

## 테스트
- [ ] 로컬 빌드 확인 (`./gradlew build`)
- [ ] 다중 기기 등록 유저에게 알림 전송 시 모든 기기에 수신 확인
- [ ] 유효하지 않은 토큰이 있을 때 해당 토큰 삭제 확인
- [ ] FCM 전송이 비동기로 동작하여 API 응답 블로킹 없음 확인

closes #557