### PR TITLE
test: Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화 #561

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -9,6 +9,21 @@
 | 2026-03-29 | [#553](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/553) | FCM 알림 통계 조회 API | teach/feat/fcm-stats-553 | FCM 성공/실패 Redis 통계 ADMIN 조회 |
 | 2026-03-29 | [#555](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/555) | 룸메이트 채팅방 입장 중 알림 차단 | teach/fix/roommate-chat-notification-555 | 채팅방 입장 중 알림 DB+FCM 생략 |
 | 2026-03-29 | [#557](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/557) | FCM 알림 다중 기기 지원 및 비동기 처리 개선 | teach/refactor/fcm-notification-improvement-557 | 다중 기기 전송, 실패 토큰 정리, @Async 처리 |
+| 2026-03-30 | [#561](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/561) | Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화 | teach/test/testcontainers-integration-test-561 | Oracle MockBean, MySQL/Redis 컨테이너, Gradle 캐시 |
+
+## 현재 작업 이슈
+
+- **번호**: #561
+- **제목**: [test] Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화
+- **브랜치**: teach/test/testcontainers-integration-test-561
+- **작업 목록**:
+  - [ ] `build.gradle`에 Testcontainers 의존성 추가 (MySQL, Redis 모듈)
+  - [ ] `src/test/resources/application-test.yml` 생성 — Oracle 비활성화, Testcontainers 연동 설정
+  - [ ] `AbstractIntegrationTest` 베이스 클래스 생성 — MySQL + Redis 컨테이너 static 선언 및 `@DynamicPropertySource`로 동적 URL 주입
+  - [ ] Oracle 관련 Bean(`SchoolLoginRepository`, `OracleConfig`) `@MockBean` 처리하는 테스트 설정 추가
+  - [ ] 기존 유닛 테스트 `@ParameterizedTest` 개선 — 채팅 권한 분기, FCM 발송 조건 등 경계값 케이스 추가
+  - [ ] CI workflow(`dev-deploy.yml`, `main-deploy.yml`)에 Gradle 의존성/래퍼 캐시 추가
+  - [ ] CI `clean build` → `build` 변경 (캐시 활용)
 
 ## 완료된 이슈
 

--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -17,13 +17,13 @@
 - **제목**: [test] Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화
 - **브랜치**: teach/test/testcontainers-integration-test-561
 - **작업 목록**:
-  - [ ] `build.gradle`에 Testcontainers 의존성 추가 (MySQL, Redis 모듈)
-  - [ ] `src/test/resources/application-test.yml` 생성 — Oracle 비활성화, Testcontainers 연동 설정
-  - [ ] `AbstractIntegrationTest` 베이스 클래스 생성 — MySQL + Redis 컨테이너 static 선언 및 `@DynamicPropertySource`로 동적 URL 주입
-  - [ ] Oracle 관련 Bean(`SchoolLoginRepository`, `OracleConfig`) `@MockBean` 처리하는 테스트 설정 추가
+  - [x] `build.gradle`에 Testcontainers 의존성 추가 (MySQL, Redis 모듈)
+  - [x] `src/test/resources/application-test.yml` 생성 — Oracle 비활성화, Testcontainers 연동 설정
+  - [x] `AbstractIntegrationTest` 베이스 클래스 생성 — MySQL + Redis 컨테이너 static 선언 및 `@DynamicPropertySource`로 동적 URL 주입
+  - [x] Oracle 관련 Bean(`SchoolLoginRepository`, `OracleConfig`) `@MockBean` 처리하는 테스트 설정 추가
   - [ ] 기존 유닛 테스트 `@ParameterizedTest` 개선 — 채팅 권한 분기, FCM 발송 조건 등 경계값 케이스 추가
-  - [ ] CI workflow(`dev-deploy.yml`, `main-deploy.yml`)에 Gradle 의존성/래퍼 캐시 추가
-  - [ ] CI `clean build` → `build` 변경 (캐시 활용)
+  - [x] CI workflow(`dev-deploy.yml`, `main-deploy.yml`)에 Gradle 의존성/래퍼 캐시 추가
+  - [x] CI `clean build` → `build` 변경 (캐시 활용)
 
 ## 완료된 이슈
 

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -30,6 +30,16 @@ jobs:
           echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 }}" | base64 --decode > ./src/main/resources/firebase/serviceAccountKey.json
 
 
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
@@ -37,7 +47,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build project
-        run: ./gradlew clean build
+        run: ./gradlew build
 
       - name: Build Docker image
         run: docker build -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_IMAGE }}:latest .

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -30,6 +30,16 @@ jobs:
           mkdir -p ./src/main/resources/firebase
           echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 }}" | base64 --decode > ./src/main/resources/firebase/serviceAccountKey.json
 
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
@@ -37,7 +47,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build project
-        run: ./gradlew clean build
+        run: ./gradlew build
 
       - name: Build Docker image
         run: docker build -t ${{ secrets.DOCKER_USERNAME }}/${{ secrets.MAIN_CONTAINER_NAME }}:latest .

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,11 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// testcontainers
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:mysql'
 //	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	// security

--- a/src/main/java/com/example/appcenter_project/domain/user/repository/SchoolLoginRepository.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/repository/SchoolLoginRepository.java
@@ -3,10 +3,12 @@ package com.example.appcenter_project.domain.user.repository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile("!test")
 @Slf4j
 public class SchoolLoginRepository {
 

--- a/src/main/java/com/example/appcenter_project/global/config/FcmConfig.java
+++ b/src/main/java/com/example/appcenter_project/global/config/FcmConfig.java
@@ -5,11 +5,13 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 @Configuration
+@Profile("!test")
 public class FcmConfig {
 
     @PostConstruct

--- a/src/test/java/com/example/appcenter_project/domain/groupOrder/service/GroupOrderChatRoomServiceTest.java
+++ b/src/test/java/com/example/appcenter_project/domain/groupOrder/service/GroupOrderChatRoomServiceTest.java
@@ -11,9 +11,13 @@ import com.example.appcenter_project.domain.groupOrder.repository.UserGroupOrder
 import com.example.appcenter_project.domain.user.entity.User;
 import com.example.appcenter_project.domain.user.repository.UserRepository;
 import com.example.appcenter_project.global.exception.CustomException;
+import com.example.appcenter_project.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -23,10 +27,12 @@ import org.mockito.quality.Strictness;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static com.example.appcenter_project.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -65,29 +71,41 @@ class GroupOrderChatRoomServiceTest {
         assertThat(mockUser.getUserGroupOrderChatRoomList()).hasSize(1);
     }
 
-    @Test
-    @DisplayName("채팅방 참여 - 공동구매 없으면 예외")
-    void joinChatRoom_공동구매_없으면_예외() {
-        when(groupOrderRepository.findById(99L)).thenReturn(Optional.empty());
+    // ===== @ParameterizedTest: joinChatRoom 예외 케이스 =====
 
-        assertThatThrownBy(() -> groupOrderChatRoomService.joinChatRoom(1L, 99L))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", GROUP_ORDER_NOT_FOUND);
+    static Stream<Arguments> joinChatRoomExceptionProvider() {
+        return Stream.of(
+            arguments("공동구매 없음",  99L, 1L,  false, true,  GROUP_ORDER_NOT_FOUND),
+            arguments("유저 없음",      1L,  99L, true,  false, USER_NOT_FOUND)
+        );
     }
 
-    @Test
-    @DisplayName("채팅방 참여 - 유저 없으면 예외")
-    void joinChatRoom_유저_없으면_예외() {
+    @ParameterizedTest(name = "{0} → {5}")
+    @MethodSource("joinChatRoomExceptionProvider")
+    @DisplayName("채팅방 참여 - 예외 케이스")
+    void joinChatRoom_예외_케이스(String scenario,
+                                  Long userId, Long groupOrderId,
+                                  boolean groupOrderExists, boolean userExists,
+                                  ErrorCode expectedError) {
         GroupOrderChatRoom mockChatRoom = mock(GroupOrderChatRoom.class);
         GroupOrder mockGroupOrder = mock(GroupOrder.class);
         when(mockGroupOrder.getGroupOrderChatRoom()).thenReturn(mockChatRoom);
 
-        when(groupOrderRepository.findById(1L)).thenReturn(Optional.of(mockGroupOrder));
-        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+        if (groupOrderExists) {
+            when(groupOrderRepository.findById(groupOrderId)).thenReturn(Optional.of(mockGroupOrder));
+        } else {
+            when(groupOrderRepository.findById(groupOrderId)).thenReturn(Optional.empty());
+        }
 
-        assertThatThrownBy(() -> groupOrderChatRoomService.joinChatRoom(99L, 1L))
+        if (userExists) {
+            when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
+        } else {
+            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+        }
+
+        assertThatThrownBy(() -> groupOrderChatRoomService.joinChatRoom(userId, groupOrderId))
                 .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", USER_NOT_FOUND);
+                .hasFieldOrPropertyWithValue("errorCode", expectedError);
     }
 
     // ===== leaveChatRoom =====

--- a/src/test/java/com/example/appcenter_project/domain/roommate/service/RoommateChattingChatServiceTest.java
+++ b/src/test/java/com/example/appcenter_project/domain/roommate/service/RoommateChattingChatServiceTest.java
@@ -14,11 +14,16 @@ import com.example.appcenter_project.domain.roommate.repository.RoommateChatting
 import com.example.appcenter_project.domain.roommate.repository.RoommateChattingRoomRepository;
 import com.example.appcenter_project.domain.user.entity.User;
 import com.example.appcenter_project.domain.user.repository.UserRepository;
+import com.example.appcenter_project.global.config.RoommateWebSocketEventListener;
 import com.example.appcenter_project.global.exception.CustomException;
 import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -27,11 +32,14 @@ import org.mockito.quality.Strictness;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static com.example.appcenter_project.global.exception.ErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -62,6 +70,11 @@ class RoommateChattingChatServiceTest {
 
     @InjectMocks
     RoommateChattingChatService roommateChattingChatService;
+
+    @AfterEach
+    void clearOnlineMap() {
+        RoommateWebSocketEventListener.roommateChatRoomInUserMap.clear();
+    }
 
     private User buildMockUser(Long id) {
         User user = mock(User.class);
@@ -196,6 +209,108 @@ class RoommateChattingChatServiceTest {
                 roommateChattingChatService.getChatList(3L, 100L, mock(HttpServletRequest.class)))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ROOMMATE_CHAT_ROOM_FORBIDDEN);
+    }
+
+    // ===== @ParameterizedTest: FCM 발송 조건 =====
+
+    @ParameterizedTest(name = "수신자 온라인={0} → FCM 발송={1}")
+    @CsvSource({
+        "false, true",   // 수신자 오프라인 → FCM 발송해야 함
+        "true,  false"   // 수신자 온라인   → FCM 미발송
+    })
+    @DisplayName("채팅 전송 - 수신자 온라인 여부에 따른 FCM 발송 조건")
+    void sendChat_FCM_발송_조건(boolean receiverOnline, boolean expectFcmSent) {
+        User guest = buildMockUser(2L);
+        User host  = buildMockUser(1L);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(guest));
+
+        RoommateChattingRoom room = mock(RoommateChattingRoom.class);
+        when(room.getId()).thenReturn(100L);
+        when(room.getGuest()).thenReturn(guest);
+        when(room.getHost()).thenReturn(host);
+        when(chatRoomRepository.findById(100L)).thenReturn(Optional.of(room));
+
+        RoommateChattingChat savedChat = mock(RoommateChattingChat.class);
+        when(savedChat.getId()).thenReturn(1L);
+        when(savedChat.getMember()).thenReturn(guest);
+        when(savedChat.getContent()).thenReturn("테스트");
+        when(savedChat.isReadByReceiver()).thenReturn(receiverOnline);
+        when(savedChat.getCreatedDate()).thenReturn(LocalDateTime.now());
+        when(savedChat.getRoommateChattingRoom()).thenReturn(room);
+        when(chatRepository.save(any(RoommateChattingChat.class))).thenReturn(savedChat);
+
+        if (receiverOnline) {
+            RoommateWebSocketEventListener.roommateChatRoomInUserMap
+                    .computeIfAbsent("100", k -> new ArrayList<>())
+                    .add("1");
+        }
+
+        Notification mockNotification = mock(Notification.class);
+        when(mockNotification.getTitle()).thenReturn("채팅 알림");
+        when(mockNotification.getBody()).thenReturn("테스트");
+        when(notificationService.createChatNotification(anyString(), anyLong(), anyString()))
+                .thenReturn(mockNotification);
+
+        RequestRoommateChatDto dto = mock(RequestRoommateChatDto.class);
+        when(dto.getRoommateChattingRoomId()).thenReturn(100L);
+        when(dto.getContent()).thenReturn("테스트");
+
+        roommateChattingChatService.sendChat(2L, dto);
+
+        if (expectFcmSent) {
+            verify(fcmMessageService).sendNotification(eq(host), anyString(), anyString());
+        } else {
+            verify(fcmMessageService, never()).sendNotification(any(), any(), any());
+        }
+    }
+
+    // ===== @ParameterizedTest: 발신자 역할(host/guest) 양방향 =====
+
+    static Stream<org.junit.jupiter.params.provider.Arguments> senderRoleProvider() {
+        return Stream.of(
+            arguments("guest가 host에게", 2L, 1L),
+            arguments("host가 guest에게", 1L, 2L)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("senderRoleProvider")
+    @DisplayName("채팅 전송 - host/guest 양방향 정상 전송")
+    void sendChat_발신자_역할별_정상_전송(String scenario, Long senderId, Long receiverId) {
+        User sender   = buildMockUser(senderId);
+        User receiver = buildMockUser(receiverId);
+        when(userRepository.findById(senderId)).thenReturn(Optional.of(sender));
+
+        RoommateChattingRoom room = mock(RoommateChattingRoom.class);
+        when(room.getId()).thenReturn(100L);
+        // senderId == 2L 이면 sender가 guest
+        when(room.getGuest()).thenReturn(senderId == 2L ? sender : receiver);
+        when(room.getHost()).thenReturn(senderId == 1L ? sender : receiver);
+        when(chatRoomRepository.findById(100L)).thenReturn(Optional.of(room));
+
+        RoommateChattingChat savedChat = mock(RoommateChattingChat.class);
+        when(savedChat.getId()).thenReturn(1L);
+        when(savedChat.getMember()).thenReturn(sender);
+        when(savedChat.getContent()).thenReturn("안녕");
+        when(savedChat.isReadByReceiver()).thenReturn(false);
+        when(savedChat.getCreatedDate()).thenReturn(LocalDateTime.now());
+        when(savedChat.getRoommateChattingRoom()).thenReturn(room);
+        when(chatRepository.save(any(RoommateChattingChat.class))).thenReturn(savedChat);
+
+        Notification mockNotification = mock(Notification.class);
+        when(mockNotification.getTitle()).thenReturn("채팅 알림");
+        when(mockNotification.getBody()).thenReturn("안녕");
+        when(notificationService.createChatNotification(anyString(), anyLong(), anyString()))
+                .thenReturn(mockNotification);
+
+        RequestRoommateChatDto dto = mock(RequestRoommateChatDto.class);
+        when(dto.getRoommateChattingRoomId()).thenReturn(100L);
+        when(dto.getContent()).thenReturn("안녕");
+
+        ResponseRoommateChatDto result = roommateChattingChatService.sendChat(senderId, dto);
+
+        assertThat(result).isNotNull();
+        verify(chatRepository).save(any(RoommateChattingChat.class));
     }
 
     @Test

--- a/src/test/java/com/example/appcenter_project/support/AbstractIntegrationTest.java
+++ b/src/test/java/com/example/appcenter_project/support/AbstractIntegrationTest.java
@@ -1,0 +1,54 @@
+package com.example.appcenter_project.support;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Testcontainers 기반 통합 테스트 베이스 클래스.
+ *
+ * <p>MySQL, Redis 컨테이너를 static으로 선언해 JVM 내 모든 하위 테스트 클래스가
+ * 동일한 컨테이너를 재사용합니다. 컨테이너는 테스트 스위트 시작 시 1회 기동되고
+ * 종료 시 자동으로 정리됩니다.
+ *
+ * <p>사용 예:
+ * <pre>{@code
+ * class UserServiceIntegrationTest extends AbstractIntegrationTest {
+ *     @Autowired UserService userService;
+ *
+ *     @Test
+ *     void someTest() { ... }
+ * }
+ * }</pre>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public abstract class AbstractIntegrationTest {
+
+    @Container
+    static final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    @Container
+    static final GenericContainer<?> redis = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+}

--- a/src/test/java/com/example/appcenter_project/support/AbstractIntegrationTest.java
+++ b/src/test/java/com/example/appcenter_project/support/AbstractIntegrationTest.java
@@ -1,7 +1,9 @@
 package com.example.appcenter_project.support;
 
+import com.example.appcenter_project.domain.user.repository.SchoolLoginRepository;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -32,6 +34,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public abstract class AbstractIntegrationTest {
+
+    // Oracle 연결 없이 테스트 가능하도록 Mock 처리
+    // 포털 로그인 검증이 필요한 테스트에서 when(schoolLoginRepository.loginCheck(...)).thenReturn("Y") 사용
+    @MockitoBean
+    protected SchoolLoginRepository schoolLoginRepository;
 
     @Container
     static final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,39 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/test        # @DynamicPropertySource가 덮어씀
+    username: test
+    password: test
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: false
+
+  flyway:
+    enabled: false
+
+  data:
+    redis:
+      host: localhost    # @DynamicPropertySource가 덮어씀
+      port: 6379
+      password: ""
+
+# JWT 테스트용 시크릿 (충분한 길이 필요)
+jwt:
+  secret: test-jwt-secret-key-that-is-long-enough-for-hmac-sha256-algorithm-test
+
+# CORS / WebSocket / Swagger 플레이스홀더
+app:
+  urls:
+    production: http://localhost:8080
+    development: http://localhost:8080
+    frontend-dev-url: http://localhost:3000
+    frontend-main-url: http://localhost:3000
+    ai-url: http://localhost:8000
+
+devServer: http://localhost:8080


### PR DESCRIPTION
## 개요
기능 수정에 따른 결함을 방지하기 위해 Testcontainers 기반 통합 테스트 환경을 구축한다.
Oracle은 MockBean으로 처리하고 MySQL/Redis는 컨테이너로 실제 환경에 가깝게 검증한다.
또한 CI workflow에 Gradle 의존성 캐시를 추가해 빌드 속도를 개선한다.

## 변경 사항
- [테스트 설정] build.gradle에 Testcontainers 의존성 추가 (b69e5d1)
- [테스트 설정] application-test.yml 생성 — Oracle 비활성화, FcmConfig 프로파일 제외 (a20ea74)
- [테스트 설정] AbstractIntegrationTest 베이스 클래스 생성 — MySQL/Redis 컨테이너 JVM 내 공유 전략 (17f018d)
- [설정] SchoolLoginRepository @Profile("!test") 분리 및 @MockitoBean 처리 (5db2f70)
- [테스트] RoommateChattingChatServiceTest — FCM 발송 조건, host/guest 양방향 @ParameterizedTest 추가 (42b5176)
- [테스트] GroupOrderChatRoomServiceTest — joinChatRoom 예외 케이스 @ParameterizedTest 통합 (42b5176)
- [CI] dev/main 워크플로우 Gradle 의존성/래퍼 캐시 추가, clean build → build 변경 (4788704)

## 테스트
- [ ] 로컬 빌드 확인 (`./gradlew build`)
- [ ] 단위 테스트 통과 확인 (`./gradlew test`)
- [ ] AbstractIntegrationTest 상속 클래스 실행 시 MySQL/Redis 컨테이너 자동 기동 확인

closes #561