### PR TITLE
feat: ADMIN 특정 유저 1:1 직접 알림 전송 기능 추가 #566

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -13,16 +13,17 @@
 
 ## 현재 작업 이슈
 
-- **번호**: #563
-- **제목**: [refactor] 공동구매 조회수 증가 Redisson 분산 락 적용
-- **브랜치**: teach/refactor/redisson-distributed-lock-563
+- **번호**: #566
+- **제목**: [feat] 특정 유저 1:1 알림 전송 기능 (ADMIN)
+- **브랜치**: teach/feat/direct-notification-566
 - **작업 목록**:
-  - [x] build.gradle에 redisson-spring-boot-starter 의존성 추가 (주석 해제)
-  - [x] RedissonConfig 설정 클래스 생성 (Redis 연결 설정)
-  - [x] 기존 공동구매 조회수 증가 로직 파악
-  - [x] GroupOrderService 조회수 증가에 RLock.tryLock(waitTime=5s, leaseTime=3s) 적용
-  - [x] 락 획득 실패 시 커스텀 예외 처리 추가
-  - [x] 분산 락 동시성 단위 테스트 작성
+  - [ ] `RequestSendDirectNotificationDto` 생성 (studentNumber, title, content)
+  - [ ] `UserRepository` 학번으로 유저 조회 메서드 확인/추가
+  - [ ] `NotificationService`에 `sendDirectNotification` 메서드 추가 (DB 저장)
+  - [ ] 기존 FCM 서비스로 해당 유저에게 푸시 알림 전송 연동
+  - [ ] `NotificationController`에 `POST /notifications/admin/direct` 엔드포인트 추가 (ADMIN)
+  - [ ] `SecurityConfig` 권한 설정
+  - [ ] `NotificationApiSpecification` Swagger 문서 업데이트
 
 ## 완료된 이슈
 
@@ -30,3 +31,4 @@
 - [x] #555 [fix] 룸메이트 채팅방 입장 중 알림 차단 → PR #556 merged
 - [x] #557 [refactor] FCM 알림 다중 기기 지원 및 비동기 처리 개선 → PR #558 merged
 - [x] #561 [test] Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화 → PR #562 merged
+- [x] #563 [refactor] 공동구매 조회수 증가 Redisson 분산 락 적용 → PR #565 merged

--- a/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationApiSpecification.java
@@ -1,6 +1,7 @@
 package com.example.appcenter_project.domain.notification.controller;
 
 import com.example.appcenter_project.domain.notification.dto.request.RequestNotificationDto;
+import com.example.appcenter_project.domain.notification.dto.request.RequestSendDirectNotificationDto;
 import com.example.appcenter_project.domain.notification.dto.response.ResponseNotificationDto;
 import com.example.appcenter_project.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -101,6 +102,21 @@ public interface NotificationApiSpecification {
             @RequestParam(required = false) Long lastId,
             @RequestParam(defaultValue = "20") int size
     );
+
+    @Operation(
+            summary = "관리자 1:1 직접 알림 전송 (ADMIN)",
+            description = "ADMIN이 특정 유저 한 명에게 직접 알림을 전송합니다. " +
+                    "학번(studentNumber)으로 대상 유저를 특정하며, DB 저장 + FCM 푸시 알림이 동시에 진행됩니다.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "알림 전송 성공"),
+                    @ApiResponse(responseCode = "403", description = "ADMIN 권한이 필요합니다."),
+                    @ApiResponse(responseCode = "404", description = "회원가입하지 않은 사용자입니다.")
+            }
+    )
+    ResponseEntity<Void> sendDirectNotification(
+            @RequestBody
+            @Parameter(description = "전송 정보 (studentNumber, title, content)", required = true)
+            RequestSendDirectNotificationDto requestDto);
 
     @Operation(
             summary = "개인 알림 전송",

--- a/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationController.java
@@ -2,6 +2,7 @@ package com.example.appcenter_project.domain.notification.controller;
 
 import com.example.appcenter_project.common.metrics.annotation.TrackApi;
 import com.example.appcenter_project.domain.notification.dto.request.RequestNotificationDto;
+import com.example.appcenter_project.domain.notification.dto.request.RequestSendDirectNotificationDto;
 import com.example.appcenter_project.domain.notification.dto.response.ResponseNotificationDto;
 import com.example.appcenter_project.global.security.CustomUserDetails;
 import com.example.appcenter_project.domain.notification.service.NotificationService;
@@ -24,6 +25,13 @@ public class NotificationController implements NotificationApiSpecification {
     @PostMapping
     public ResponseEntity<Void> saveNotification(@RequestBody RequestNotificationDto requestNotificationDto) {
         notificationService.saveNotification(requestNotificationDto);
+        return ResponseEntity.status(CREATED).build();
+    }
+
+    @TrackApi
+    @PostMapping("/admin/direct")
+    public ResponseEntity<Void> sendDirectNotification(@RequestBody RequestSendDirectNotificationDto requestDto) {
+        notificationService.sendDirectNotification(requestDto);
         return ResponseEntity.status(CREATED).build();
     }
 

--- a/src/main/java/com/example/appcenter_project/domain/notification/dto/request/RequestSendDirectNotificationDto.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/dto/request/RequestSendDirectNotificationDto.java
@@ -1,0 +1,11 @@
+package com.example.appcenter_project.domain.notification.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class RequestSendDirectNotificationDto {
+
+    private String studentNumber;
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/example/appcenter_project/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/service/NotificationService.java
@@ -1,6 +1,8 @@
 package com.example.appcenter_project.domain.notification.service;
 
 import com.example.appcenter_project.domain.notification.dto.request.RequestNotificationDto;
+import com.example.appcenter_project.domain.notification.dto.request.RequestSendDirectNotificationDto;
+import com.example.appcenter_project.shared.enums.ApiType;
 import com.example.appcenter_project.domain.notification.dto.response.ResponseNotificationDto;
 import com.example.appcenter_project.domain.notification.entity.Notification;
 import com.example.appcenter_project.domain.notification.entity.UserNotification;
@@ -42,6 +44,22 @@ public class NotificationService {
 
         saveUserNotifications(notification, receiveUsers);
         sendFcmMessages(notification, receiveUsers);
+    }
+
+    public void sendDirectNotification(RequestSendDirectNotificationDto requestDto) {
+        User user = userRepository.findByStudentNumber(requestDto.getStudentNumber())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        Notification notification = Notification.of(
+                requestDto.getTitle(),
+                requestDto.getContent(),
+                NotificationType.UNI_DORM,
+                ApiType.NOTIFICATION,
+                null
+        );
+        notificationRepository.save(notification);
+        createUserNotification(user, notification);
+        fcmMessageService.sendNotification(user, requestDto.getTitle(), requestDto.getContent());
     }
 
     public void saveNotificationByStudentNumber(RequestNotificationDto requestDto, String studentNumber) {

--- a/src/main/java/com/example/appcenter_project/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/appcenter_project/global/config/SecurityConfig.java
@@ -128,6 +128,8 @@ public class SecurityConfig {
                             .hasAnyRole("DORM_SUPPORTERS", "ADMIN", "DORM_LIFE_MANAGER", "DORM_ROOMMATE_MANAGER", "DORM_MANAGER", "DORM_EXPEDITED_COMPLAINT_MANAGER")
 
                         /** 알림 **/
+                        // 특정 유저 1:1 직접 알림 전송(ADMIN 전용)
+                        .requestMatchers(POST, "/notifications/admin/direct").hasRole("ADMIN")
                         // 알림 조회(로그인한 사용자)
                         .requestMatchers(GET, "/notifications/**").permitAll()
                         // 알림 등록, 수정, 삭제(관리자)


### PR DESCRIPTION
## 개요
ADMIN이 특정 유저 한 명에게만 알림을 보낼 수 있는 기능을 추가합니다.
학번(studentNumber)으로 대상 유저를 특정하고 제목과 내용을 입력하면
FCM 푸시 알림 전송과 DB 알림 저장이 동시에 이루어집니다.

## 변경 사항
- [DTO] RequestSendDirectNotificationDto 생성 (studentNumber, title, content)
- [서비스] NotificationService에 sendDirectNotification 메서드 추가 - DB 저장 + FCM 푸시 연동 (8fc9d0d)
- [API] POST /notifications/admin/direct 엔드포인트 추가 (ADMIN 전용)
- [설정] SecurityConfig에 /notifications/admin/direct ADMIN 전용 권한 규칙 추가
- [문서] NotificationApiSpecification Swagger 문서 업데이트

## 테스트
- [ ] 로컬 빌드 확인 (`./gradlew build`)
- [ ] ADMIN 계정으로 POST /notifications/admin/direct 요청 시 대상 유저 알림 수신 확인
- [ ] 존재하지 않는 학번 입력 시 404 응답 확인
- [ ] ADMIN 외 권한으로 요청 시 403 응답 확인

closes #566