### PR TITLE
docs: 알림 API notificationType 유효 값 Swagger 문서화 #568

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -11,6 +11,15 @@
 | 2026-03-29 | [#557](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/557) | FCM 알림 다중 기기 지원 및 비동기 처리 개선 | teach/refactor/fcm-notification-improvement-557 | 다중 기기 전송, 실패 토큰 정리, @Async 처리 |
 | 2026-03-30 | [#561](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/561) | Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화 | teach/test/testcontainers-integration-test-561 | Oracle MockBean, MySQL/Redis 컨테이너, Gradle 캐시 |
 
+## 현재 작업 이슈
+
+- **번호**: #568
+- **제목**: [docs] 알림 API Swagger notificationType 유효 값 명시
+- **브랜치**: teach/docs/notification-type-swagger-568
+- **작업 목록**:
+  - [ ] `NotificationApiSpecification`의 알림 생성(`saveNotification`) API에 `notificationType` 유효 값 명시
+  - [ ] `RequestNotificationDto`에 `@Schema` 어노테이션으로 유효 값 추가
+
 ## 완료된 이슈
 
 - [x] #553 [feat] FCM 알림 통계 조회 API → PR #554 merged

--- a/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationApiSpecification.java
@@ -24,9 +24,21 @@ public interface NotificationApiSpecification {
 
     @Operation(
             summary = "알림 생성",
-            description = "새로운 알림을 생성하고 대상 사용자들에게 푸시 알림을 전송합니다. " +
-                    "    ROOMMATE, GROUP_ORDER, DORMITORY, UNI_DORM, SUPPORTERS \n" +
-                    "    COMPLAINT, COUPON, CHAT",
+            description = """
+                    새로운 알림을 생성하고 대상 사용자들에게 푸시 알림을 전송합니다.
+
+                    ### notificationType 유효 값
+                    | 영문 (권장) | 한글 |
+                    |---|---|
+                    | ROOMMATE | 룸메이트 |
+                    | GROUP_ORDER | 공동구매 |
+                    | DORMITORY | 생활원 |
+                    | UNI_DORM | 유니돔 |
+                    | SUPPORTERS | 서포터즈 |
+                    | COMPLAINT | 민원 |
+                    | COUPON | 쿠폰 |
+                    | CHAT | 채팅 |
+                    """,
             responses = {
                     @ApiResponse(responseCode = "201", description = "알림 생성 성공"),
                     @ApiResponse(responseCode = "400", description = "입력이 잘못되었습니다."),
@@ -35,7 +47,7 @@ public interface NotificationApiSpecification {
     )
     ResponseEntity<Void> saveNotification(
             @RequestBody
-            @Parameter(description = "알림 생성 정보 (title, body, notificationType, boardId)", required = true)
+            @Parameter(description = "알림 생성 정보 (title, body, notificationType)", required = true)
             RequestNotificationDto requestNotificationDto);
 
     @Operation(

--- a/src/main/java/com/example/appcenter_project/domain/notification/dto/request/RequestNotificationDto.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/dto/request/RequestNotificationDto.java
@@ -3,6 +3,7 @@ package com.example.appcenter_project.domain.notification.dto.request;
 import com.example.appcenter_project.domain.notification.entity.Notification;
 import com.example.appcenter_project.shared.enums.ApiType;
 import com.example.appcenter_project.domain.user.enums.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
@@ -10,5 +11,11 @@ public class RequestNotificationDto {
 
     private String title;
     private String body;
+
+    @Schema(
+            description = "알림 타입 (영문 또는 한글 모두 허용)",
+            allowableValues = {"ROOMMATE", "GROUP_ORDER", "DORMITORY", "UNI_DORM", "SUPPORTERS", "COMPLAINT", "COUPON", "CHAT"},
+            example = "UNI_DORM"
+    )
     private String notificationType;
 }


### PR DESCRIPTION
## 개요
알림 생성 API의 notificationType 필드에 어떤 값을 입력해야 하는지 Swagger 문서에 명시되어 있지 않아
개발자가 유효 값을 직접 코드에서 찾아야 하는 불편함이 있었습니다.
Swagger 문서와 DTO에 유효 값을 명시하여 API 사용성을 개선합니다.

## 변경 사항
- [문서] NotificationApiSpecification saveNotification 설명에 notificationType 유효 값 표 추가 (224a955)
- [DTO] RequestNotificationDto notificationType 필드에 @Schema 어노테이션으로 allowableValues 명시

## 테스트
- [ ] 로컬 빌드 확인 (`./gradlew build`)
- [ ] Swagger UI에서 알림 생성 API의 notificationType 필드에 유효 값이 표시되는지 확인

closes #568