### PR TITLE
refactor: 개인 알림 전송 API 통합 및 notificationType Swagger 문서화 #570

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -11,6 +11,17 @@
 | 2026-03-29 | [#557](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/557) | FCM 알림 다중 기기 지원 및 비동기 처리 개선 | teach/refactor/fcm-notification-improvement-557 | 다중 기기 전송, 실패 토큰 정리, @Async 처리 |
 | 2026-03-30 | [#561](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/561) | Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화 | teach/test/testcontainers-integration-test-561 | Oracle MockBean, MySQL/Redis 컨테이너, Gradle 캐시 |
 
+## 현재 작업 이슈
+
+- **번호**: #570
+- **제목**: [refactor] 개인 알림 전송 API 통합 및 notificationType Swagger 문서화
+- **브랜치**: teach/refactor/notification-api-merge-570
+- **작업 목록**:
+  - [ ] saveNotificationByStudentNumber API 제거 (컨트롤러, 서비스, ApiSpecification)
+  - [ ] RequestSendDirectNotificationDto에 notificationType 필드 추가 (미입력 시 UNI_DORM 기본값)
+  - [ ] sendDirectNotification 서비스 로직에서 notificationType 반영
+  - [ ] sendDirectNotification Swagger 문서에 notificationType 유효 값 영문으로 문서화
+
 ## 완료된 이슈
 
 - [x] #553 [feat] FCM 알림 통계 조회 API → PR #554 merged

--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -11,17 +11,6 @@
 | 2026-03-29 | [#557](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/557) | FCM 알림 다중 기기 지원 및 비동기 처리 개선 | teach/refactor/fcm-notification-improvement-557 | 다중 기기 전송, 실패 토큰 정리, @Async 처리 |
 | 2026-03-30 | [#561](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/561) | Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화 | teach/test/testcontainers-integration-test-561 | Oracle MockBean, MySQL/Redis 컨테이너, Gradle 캐시 |
 
-## 현재 작업 이슈
-
-- **번호**: #570
-- **제목**: [refactor] 개인 알림 전송 API 통합 및 notificationType Swagger 문서화
-- **브랜치**: teach/refactor/notification-api-merge-570
-- **작업 목록**:
-  - [ ] saveNotificationByStudentNumber API 제거 (컨트롤러, 서비스, ApiSpecification)
-  - [ ] RequestSendDirectNotificationDto에 notificationType 필드 추가 (미입력 시 UNI_DORM 기본값)
-  - [ ] sendDirectNotification 서비스 로직에서 notificationType 반영
-  - [ ] sendDirectNotification Swagger 문서에 notificationType 유효 값 영문으로 문서화
-
 ## 완료된 이슈
 
 - [x] #553 [feat] FCM 알림 통계 조회 API → PR #554 merged
@@ -31,3 +20,4 @@
 - [x] #563 [refactor] 공동구매 조회수 증가 Redisson 분산 락 적용 → PR #565 merged
 - [x] #566 [feat] 특정 유저 1:1 알림 전송 기능 (ADMIN) → PR #567 merged
 - [x] #568 [docs] 알림 API Swagger notificationType 유효 값 명시 → PR #569 merged
+- [x] #570 [refactor] 개인 알림 전송 API 통합 및 notificationType Swagger 문서화 → PR #571 merged

--- a/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationApiSpecification.java
@@ -117,8 +117,22 @@ public interface NotificationApiSpecification {
 
     @Operation(
             summary = "관리자 1:1 직접 알림 전송 (ADMIN)",
-            description = "ADMIN이 특정 유저 한 명에게 직접 알림을 전송합니다. " +
-                    "학번(studentNumber)으로 대상 유저를 특정하며, DB 저장 + FCM 푸시 알림이 동시에 진행됩니다.",
+            description = """
+                    ADMIN이 특정 유저 한 명에게 직접 알림을 전송합니다.
+                    학번(studentNumber)으로 대상 유저를 특정하며, DB 저장 + FCM 푸시 알림이 동시에 진행됩니다.
+
+                    ### notificationType 유효 값 (미입력 시 UNI_DORM 기본값)
+                    | Value | Description |
+                    |---|---|
+                    | ROOMMATE | 룸메이트 |
+                    | GROUP_ORDER | 공동구매 |
+                    | DORMITORY | 생활원 |
+                    | UNI_DORM | 유니돔 |
+                    | SUPPORTERS | 서포터즈 |
+                    | COMPLAINT | 민원 |
+                    | COUPON | 쿠폰 |
+                    | CHAT | 채팅 |
+                    """,
             responses = {
                     @ApiResponse(responseCode = "201", description = "알림 전송 성공"),
                     @ApiResponse(responseCode = "403", description = "ADMIN 권한이 필요합니다."),
@@ -127,14 +141,8 @@ public interface NotificationApiSpecification {
     )
     ResponseEntity<Void> sendDirectNotification(
             @RequestBody
-            @Parameter(description = "전송 정보 (studentNumber, title, content)", required = true)
+            @Parameter(description = "전송 정보 (studentNumber, title, content, notificationType)", required = true)
             RequestSendDirectNotificationDto requestDto);
-
-    @Operation(
-            summary = "개인 알림 전송",
-            description = "학번을 통해서 개인 알림이 전송됩니다.(푸시 알림 포함)"
-    )
-    ResponseEntity<Void> saveNotificationByStudentNumber(@RequestBody RequestNotificationDto requestNotificationDto, String studentNumber);
 
 
     @Operation(

--- a/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationController.java
@@ -35,12 +35,6 @@ public class NotificationController implements NotificationApiSpecification {
         return ResponseEntity.status(CREATED).build();
     }
 
-    @PostMapping("/student-number/{studentNumber}")
-    public ResponseEntity<Void> saveNotificationByStudentNumber(@RequestBody RequestNotificationDto requestNotificationDto, String studentNumber) {
-        notificationService.saveNotificationByStudentNumber(requestNotificationDto, studentNumber);
-        return ResponseEntity.status(CREATED).build();
-    }
-
     @TrackApi
     @GetMapping("/{notificationId}")
     public ResponseEntity<ResponseNotificationDto> findNotification(@AuthenticationPrincipal CustomUserDetails user, @PathVariable("notificationId") Long notificationId) {

--- a/src/main/java/com/example/appcenter_project/domain/notification/dto/request/RequestSendDirectNotificationDto.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/dto/request/RequestSendDirectNotificationDto.java
@@ -1,5 +1,6 @@
 package com.example.appcenter_project.domain.notification.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
@@ -8,4 +9,11 @@ public class RequestSendDirectNotificationDto {
     private String studentNumber;
     private String title;
     private String content;
+
+    @Schema(
+            description = "알림 타입 (미입력 시 UNI_DORM 기본값)",
+            allowableValues = {"ROOMMATE", "GROUP_ORDER", "DORMITORY", "UNI_DORM", "SUPPORTERS", "COMPLAINT", "COUPON", "CHAT"},
+            example = "UNI_DORM"
+    )
+    private String notificationType;
 }

--- a/src/main/java/com/example/appcenter_project/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/service/NotificationService.java
@@ -50,27 +50,20 @@ public class NotificationService {
         User user = userRepository.findByStudentNumber(requestDto.getStudentNumber())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
+        NotificationType notificationType = requestDto.getNotificationType() != null
+                ? NotificationType.from(requestDto.getNotificationType())
+                : NotificationType.UNI_DORM;
+
         Notification notification = Notification.of(
                 requestDto.getTitle(),
                 requestDto.getContent(),
-                NotificationType.UNI_DORM,
+                notificationType,
                 ApiType.NOTIFICATION,
                 null
         );
         notificationRepository.save(notification);
         createUserNotification(user, notification);
         fcmMessageService.sendNotification(user, requestDto.getTitle(), requestDto.getContent());
-    }
-
-    public void saveNotificationByStudentNumber(RequestNotificationDto requestDto, String studentNumber) {
-        String title = "유니돔으로부터 알림이 도착했습니다!";
-
-        User user = userRepository.findByStudentNumber(studentNumber).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-
-        Notification notification = createNotification(requestDto);
-        createUserNotification(user, notification);
-
-        fcmMessageService.sendNotification(user, title, notification.getTitle());
     }
 
     public ResponseNotificationDto findNotification(Long userId, Long notificationId) {


### PR DESCRIPTION
## 개요
POST /notifications/student-number/{studentNumber} API가 POST /notifications/admin/direct와 기능이 중복되어 있었습니다.
중복 API를 제거하고 /notifications/admin/direct 하나로 통합하며, notificationType 유효 값을 Swagger에 영문으로 문서화합니다.

## 변경 사항
- [API] saveNotificationByStudentNumber 엔드포인트 제거 (컨트롤러, 서비스, ApiSpecification)
- [DTO] RequestSendDirectNotificationDto에 notificationType 필드 추가 (미입력 시 UNI_DORM 기본값)
- [Service] sendDirectNotification에서 notificationType 동적 반영
- [Docs] sendDirectNotification Swagger에 notificationType 유효 값 영문 테이블 추가

## 테스트
- [ ] 로컬 빌드 확인 (`./gradlew build`)
- [ ] POST /notifications/admin/direct 호출 시 notificationType 미입력 → UNI_DORM으로 저장 확인
- [ ] POST /notifications/admin/direct 호출 시 notificationType 입력 → 해당 타입으로 저장 확인
- [ ] POST /notifications/student-number/{studentNumber} 제거 후 404 응답 확인

closes #570