### PR TITLE
feat: ADMIN 특정 유저 Role 변경 기능 #572

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -11,6 +11,18 @@
 | 2026-03-29 | [#557](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/557) | FCM 알림 다중 기기 지원 및 비동기 처리 개선 | teach/refactor/fcm-notification-improvement-557 | 다중 기기 전송, 실패 토큰 정리, @Async 처리 |
 | 2026-03-30 | [#561](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/561) | Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화 | teach/test/testcontainers-integration-test-561 | Oracle MockBean, MySQL/Redis 컨테이너, Gradle 캐시 |
 
+## 현재 작업 이슈
+
+- **번호**: #572
+- **제목**: [feat] ADMIN 특정 유저 Role 변경 기능
+- **브랜치**: teach/feat/user-role-change-572
+- **작업 목록**:
+  - [ ] RequestChangeUserRoleDto 생성 (studentNumber, role)
+  - [ ] UserService에 changeUserRole 메서드 추가
+  - [ ] UserController에 PATCH /users/role 엔드포인트 추가 (ADMIN 전용)
+  - [ ] UserApiSpecification에 Swagger 문서 추가 (Role 유효 값 포함)
+  - [ ] SecurityConfig에 PATCH /users/role ADMIN 권한 설정 추가
+
 ## 완료된 이슈
 
 - [x] #553 [feat] FCM 알림 통계 조회 API → PR #554 merged

--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -11,18 +11,6 @@
 | 2026-03-29 | [#557](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/557) | FCM 알림 다중 기기 지원 및 비동기 처리 개선 | teach/refactor/fcm-notification-improvement-557 | 다중 기기 전송, 실패 토큰 정리, @Async 처리 |
 | 2026-03-30 | [#561](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/561) | Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화 | teach/test/testcontainers-integration-test-561 | Oracle MockBean, MySQL/Redis 컨테이너, Gradle 캐시 |
 
-## 현재 작업 이슈
-
-- **번호**: #572
-- **제목**: [feat] ADMIN 특정 유저 Role 변경 기능
-- **브랜치**: teach/feat/user-role-change-572
-- **작업 목록**:
-  - [ ] RequestChangeUserRoleDto 생성 (studentNumber, role)
-  - [ ] UserService에 changeUserRole 메서드 추가
-  - [ ] UserController에 PATCH /users/role 엔드포인트 추가 (ADMIN 전용)
-  - [ ] UserApiSpecification에 Swagger 문서 추가 (Role 유효 값 포함)
-  - [ ] SecurityConfig에 PATCH /users/role ADMIN 권한 설정 추가
-
 ## 완료된 이슈
 
 - [x] #553 [feat] FCM 알림 통계 조회 API → PR #554 merged
@@ -33,3 +21,4 @@
 - [x] #566 [feat] 특정 유저 1:1 알림 전송 기능 (ADMIN) → PR #567 merged
 - [x] #568 [docs] 알림 API Swagger notificationType 유효 값 명시 → PR #569 merged
 - [x] #570 [refactor] 개인 알림 전송 API 통합 및 notificationType Swagger 문서화 → PR #571 merged
+- [x] #572 [feat] ADMIN 특정 유저 Role 변경 기능 → PR #573 merged

--- a/src/main/java/com/example/appcenter_project/domain/user/controller/UserApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/controller/UserApiSpecification.java
@@ -102,9 +102,27 @@ public interface UserApiSpecification {
     ResponseEntity<Void> sendPushNotification(@RequestBody RequestUserPushNotification requestUserPushNotification);
 
     @Operation(
-            summary = "사용자 권한 변경",
-            description = "생활원 직원, 관리자만 특정 사용자의 권한을 생활원 직원으로 변경할 수 있음" +
-                    "(role : 기숙사 담당자, 기숙사 생활민원 담당자, 기숙사 룸메이트민원 담당자)"
+            summary = "사용자 권한 변경 (ADMIN)",
+            description = """
+                    ADMIN이 특정 유저의 Role을 변경합니다.
+                    학번(studentNumber)으로 대상 유저를 특정하고, 변경할 role을 입력합니다.
+
+                    ### role 유효 값
+                    | Value | Description |
+                    |---|---|
+                    | ROLE_ADMIN | 관리자 |
+                    | ROLE_USER | 일반 사용자 |
+                    | ROLE_DORM_MANAGER | 기숙사 담당자 |
+                    | ROLE_DORM_LIFE_MANAGER | 기숙사 생활민원 담당자 |
+                    | ROLE_DORM_ROOMMATE_MANAGER | 기숙사 룸메이트민원 담당자 |
+                    | ROLE_DORM_EXPEDITED_COMPLAINT_MANAGER | 기숙사 신속민원 담당자 |
+                    | ROLE_DORM_SUPPORTERS | 기숙사 서포터즈 |
+                    """,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "권한 변경 성공"),
+                    @ApiResponse(responseCode = "403", description = "ADMIN 권한이 필요합니다."),
+                    @ApiResponse(responseCode = "404", description = "회원가입하지 않은 사용자입니다.")
+            }
     )
     ResponseEntity<Void> changeUserRole(@RequestBody RequestUserRoleDto requestUserRoleDto);
 

--- a/src/main/java/com/example/appcenter_project/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/controller/UserController.java
@@ -68,10 +68,10 @@ public class UserController implements UserApiSpecification {
         return ResponseEntity.status(CREATED).build();
     }
 
-    @PostMapping("/role")
+    @PatchMapping("/role")
     public ResponseEntity<Void> changeUserRole(@RequestBody RequestUserRoleDto request) {
         userService.changeUserRole(request);
-        return ResponseEntity.status(CREATED).build();
+        return ResponseEntity.status(OK).build();
     }
 
     @GetMapping

--- a/src/main/java/com/example/appcenter_project/domain/user/service/UserService.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/service/UserService.java
@@ -89,10 +89,8 @@ public class UserService {
 
     public void changeUserRole(RequestUserRoleDto request) {
         Role role = Role.from(request.getRole());
-        if (isNotAdminRole(role)) {
-            User user = userRepository.findByStudentNumber(request.getStudentNumber()).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-            user.changeRole(role);
-        }
+        User user = userRepository.findByStudentNumber(request.getStudentNumber()).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        user.changeRole(role);
     }
 
     public ResponseUserDto findUser(Long userId) {

--- a/src/main/java/com/example/appcenter_project/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/appcenter_project/global/config/SecurityConfig.java
@@ -54,8 +54,10 @@ public class SecurityConfig {
                         .requestMatchers("/users/all/admin").hasRole("ADMIN")
                         // 특정 유저 푸시 알림 전송
                         .requestMatchers( "/users/push-notification").hasRole("ADMIN")
-                        // 사용자 권한 수정 및 조회
-                        .requestMatchers("/users/role")
+                        // 사용자 권한 변경 (ADMIN 전용)
+                        .requestMatchers(PATCH, "/users/role").hasRole("ADMIN")
+                        // 사용자 권한 조회
+                        .requestMatchers(GET, "/users/role")
                             .hasAnyRole("DORM_LIFE_MANAGER", "DORM_ROOMMATE_MANAGER", "DORM_MANAGER", "DORM_EXPEDITED_COMPLAINT_MANAGER","ADMIN")
                         // 사용자 정보 조회 및 수정
                         .requestMatchers("/users", "/users/image", "/users/time-table-image").authenticated()


### PR DESCRIPTION
## 개요
ADMIN이 특정 유저의 Role을 변경할 수 있는 기능을 개선합니다.
기존 POST /users/role를 PATCH로 변경하고, ADMIN 전용으로 권한을 제한하며
Role 유효 값을 Swagger에 영문으로 문서화합니다.

## 변경 사항
- [API] POST /users/role → PATCH /users/role로 HTTP 메서드 변경
- [설정] SecurityConfig PATCH /users/role ADMIN 전용 권한 설정 (GET은 기존 유지)
- [Service] changeUserRole에서 ROLE_ADMIN 변경 제한(isNotAdminRole) 제거
- [Docs] UserApiSpecification에 Role 유효 값 영문 테이블 추가 (fbca82f)

## 테스트
- [ ] 로컬 빌드 확인 (`./gradlew build`)
- [ ] PATCH /users/role 호출 시 ADMIN 권한으로 Role 변경 확인
- [ ] PATCH /users/role 호출 시 비ADMIN 계정으로 403 응답 확인
- [ ] GET /users/role 기존 DORM 담당자 권한으로 정상 조회 확인

closes #572