### PR TITLE
fix: Refresh Token Rotation 적용으로 다중 기기 토큰 갱신 보안 강화 #577

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -10,6 +10,7 @@
 | 2026-03-29 | [#555](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/555) | 룸메이트 채팅방 입장 중 알림 차단 | teach/fix/roommate-chat-notification-555 | 채팅방 입장 중 알림 DB+FCM 생략 |
 | 2026-03-29 | [#557](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/557) | FCM 알림 다중 기기 지원 및 비동기 처리 개선 | teach/refactor/fcm-notification-improvement-557 | 다중 기기 전송, 실패 토큰 정리, @Async 처리 |
 | 2026-03-30 | [#561](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/561) | Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화 | teach/test/testcontainers-integration-test-561 | Oracle MockBean, MySQL/Redis 컨테이너, Gradle 캐시 |
+| 2026-04-03 | [#577](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/577) | Refresh Token Rotation 적용 | teach/fix/refresh-token-rotation-577 | 재발급 시 기존 RefreshToken 삭제 후 새 토큰 함께 발급 |
 
 ## 완료된 이슈
 

--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -23,3 +23,4 @@
 - [x] #568 [docs] 알림 API Swagger notificationType 유효 값 명시 → PR #569 merged
 - [x] #570 [refactor] 개인 알림 전송 API 통합 및 notificationType Swagger 문서화 → PR #571 merged
 - [x] #572 [feat] ADMIN 특정 유저 Role 변경 기능 → PR #573 merged
+- [x] #577 [fix] Refresh Token Rotation 적용으로 다중 기기 토큰 갱신 보안 강화 → PR #578 merged

--- a/src/main/java/com/example/appcenter_project/domain/user/controller/UserApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/controller/UserApiSpecification.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -75,12 +74,12 @@ public interface UserApiSpecification {
             @Parameter(description = "신입생 로그인 정보", required = true) SignupUser signupUser);
 
     @Operation(
-            summary = "액세스 토큰 재발급",
-            description = "유효한 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.",
+            summary = "액세스 토큰 재발급 (Refresh Token Rotation)",
+            description = "유효한 리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 함께 발급받습니다. 기존 리프레시 토큰은 즉시 무효화되므로, 응답으로 받은 새 리프레시 토큰을 저장해야 합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
                             content = @Content(mediaType = "application/json",
-                                    examples = @ExampleObject(value = "{\"accessToken\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...\"}"))),
+                                    schema = @Schema(implementation = ResponseLoginDto.class))),
                     @ApiResponse(responseCode = "401",
                             description = "유효하지 않은 Refresh Token입니다. (INVALID_REFRESH_TOKEN)",
                             content = @Content(examples = {})),
@@ -90,7 +89,7 @@ public interface UserApiSpecification {
                     )
             }
     )
-    ResponseEntity<?> reissueAccessToken(
+    ResponseEntity<ResponseLoginDto> reissueAccessToken(
             @RequestBody
             @Parameter RequestTokenDto requestTokenDto
     );

--- a/src/main/java/com/example/appcenter_project/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/controller/UserController.java
@@ -7,7 +7,6 @@ import com.example.appcenter_project.domain.user.dto.response.ResponseBoardDto;
 import com.example.appcenter_project.domain.user.dto.response.ResponseLoginDto;
 import com.example.appcenter_project.domain.user.dto.response.ResponseUserDto;
 import com.example.appcenter_project.domain.user.dto.response.ResponseUserRole;
-import com.example.appcenter_project.global.exception.CustomException;
 import com.example.appcenter_project.global.security.CustomUserDetails;
 import com.example.appcenter_project.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -24,7 +23,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.springframework.http.HttpStatus.*;
 
@@ -53,13 +51,8 @@ public class UserController implements UserApiSpecification {
     }
 
     @PostMapping("/refreshToken")
-    public ResponseEntity<?> reissueAccessToken(@RequestBody RequestTokenDto request) {
-        try {
-            String newAccessToken = userService.reissueAccessToken(request);
-            return ResponseEntity.ok(Map.of("accessToken", newAccessToken));
-        } catch (IllegalArgumentException | CustomException e) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
-        }
+    public ResponseEntity<ResponseLoginDto> reissueAccessToken(@RequestBody RequestTokenDto request) {
+        return ResponseEntity.ok(userService.reissueAccessToken(request));
     }
 
     @PostMapping("/push-notification")

--- a/src/main/java/com/example/appcenter_project/domain/user/service/UserService.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/service/UserService.java
@@ -73,7 +73,7 @@ public class UserService {
         return createDto(user);
     }
 
-    public String reissueAccessToken(RequestTokenDto request) {
+    public ResponseLoginDto reissueAccessToken(RequestTokenDto request) {
         validateRefreshToken(request.getRefreshToken());
         String refreshToken = extractBearerToken(request);
         return reissueAccessTokenByRefreshToken(refreshToken);
@@ -279,7 +279,7 @@ public class UserService {
 
     private void validateRefreshToken(String token) {
         if (token == null || !token.startsWith("Bearer ")) {
-            throw new IllegalArgumentException("Refresh Token이 유효하지 않습니다.");
+            throw new CustomException(INVALID_REFRESH_TOKEN);
         }
     }
 
@@ -287,7 +287,7 @@ public class UserService {
         return request.getRefreshToken().substring(7);
     }
 
-    private String reissueAccessTokenByRefreshToken(String refreshToken) {
+    private ResponseLoginDto reissueAccessTokenByRefreshToken(String refreshToken) {
         if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
             throw new CustomException(INVALID_REFRESH_TOKEN);
         }
@@ -296,7 +296,12 @@ public class UserService {
                 .orElseThrow(() -> new CustomException(REFRESH_TOKEN_USER_NOT_FOUND));
         User user = refreshTokenEntity.getUser();
 
-        return jwtTokenProvider.generateAccessToken(user.getId(), user.getStudentNumber(), String.valueOf(user.getRole()));
+        refreshTokenRepository.delete(refreshTokenEntity);
+
+        String newAccessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getStudentNumber(), String.valueOf(user.getRole()));
+        String newRefreshToken = createRefreshToken(user);
+
+        return new ResponseLoginDto(newAccessToken, newRefreshToken, user.getRole().toString());
     }
 
     private void sendMessageToUsers(List<User> userIds, String title, String body) {


### PR DESCRIPTION
## 개요
Access Token 재발급 시 기존 Refresh Token이 DB에 유지되어 rotation이 적용되지 않는 문제를 수정한다.
재발급 시 기존 Refresh Token을 삭제하고 새 Refresh Token을 함께 발급하는 Rotation 방식을 적용하여,
각 기기가 독립적인 토큰 체인을 유지하고 탈취된 토큰의 재사용을 방지한다.

## 변경 사항
- [Service] `UserService.reissueAccessTokenByRefreshToken()` - 기존 RefreshToken 삭제 후 새 RefreshToken 발급 및 저장 (f55560f)
- [Service] `UserService.reissueAccessToken()` 반환 타입 `String` → `ResponseLoginDto`로 변경 (f55560f)
- [API] `UserController.reissueAccessToken()` - 응답에 `accessToken` + `refreshToken` 모두 포함 (f55560f)
- [Docs] `UserApiSpecification` Swagger 설명 및 응답 스키마 업데이트 (f55560f)

## 테스트
- [ ] 로컬 빌드 확인 (`./gradlew build`)
- [ ] `POST /users/refreshToken` 호출 시 응답에 `accessToken`, `refreshToken` 모두 포함 확인
- [ ] 재발급 후 이전 RefreshToken으로 재시도 시 404 응답 확인
- [ ] 두 기기 각각 독립적으로 토큰 재발급 가능 확인

closes #577