### PR TITLE
fix: FcmMessageService @Async 메서드 LazyInitializationException 수정 #579

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -11,6 +11,7 @@
 | 2026-03-29 | [#557](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/557) | FCM 알림 다중 기기 지원 및 비동기 처리 개선 | teach/refactor/fcm-notification-improvement-557 | 다중 기기 전송, 실패 토큰 정리, @Async 처리 |
 | 2026-03-30 | [#561](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/561) | Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화 | teach/test/testcontainers-integration-test-561 | Oracle MockBean, MySQL/Redis 컨테이너, Gradle 캐시 |
 | 2026-04-03 | [#577](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/577) | Refresh Token Rotation 적용 | teach/fix/refresh-token-rotation-577 | 재발급 시 기존 RefreshToken 삭제 후 새 토큰 함께 발급 |
+| 2026-04-03 | [#579](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/579) | FcmMessageService @Async LazyInitializationException 수정 | teach/fix/fcm-lazy-init-579 | @Async 메서드에서 Lazy 컬렉션 직접 접근 제거 |
 
 ## 완료된 이슈
 

--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -25,3 +25,4 @@
 - [x] #570 [refactor] 개인 알림 전송 API 통합 및 notificationType Swagger 문서화 → PR #571 merged
 - [x] #572 [feat] ADMIN 특정 유저 Role 변경 기능 → PR #573 merged
 - [x] #577 [fix] Refresh Token Rotation 적용으로 다중 기기 토큰 갱신 보안 강화 → PR #578 merged
+- [x] #579 [fix] FcmMessageService @Async 메서드 LazyInitializationException 수정 → PR #580 merged

--- a/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmMessageService.java
+++ b/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmMessageService.java
@@ -37,10 +37,11 @@ public class FcmMessageService {
     private final UserRepository userRepository;
     private final RedisTemplate<String, Object> redisTemplate;
 
-    // todo User user
     @Async("fcmExecutor")
     public void sendNotification(User user, String title, String body) {
-        for (FcmToken fcmToken : user.getFcmTokenList()) {
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        for (FcmToken fcmToken : fcmTokenRepository.findAllByUser(freshUser)) {
             String targetToken = fcmToken.getToken();
 
             Notification notification = Notification.builder()
@@ -107,30 +108,29 @@ public class FcmMessageService {
 
     @Async("fcmExecutor")
     public void sendNotificationDormitoryPerson(String title, String body) {
-        for (User user : userRepository.findByDormTypeNot(DormType.NONE)) {
-            if (user.getReceiveNotificationTypes().contains(NotificationType.DORMITORY)) {
-                for (FcmToken fcmToken : user.getFcmTokenList()) {
-                    String targetToken = fcmToken.getToken();
+        List<User> dormitoryUsers = userRepository.findDormitoryUsersWithFcmTokens(DormType.NONE, NotificationType.DORMITORY);
+        for (User user : dormitoryUsers) {
+            for (FcmToken fcmToken : user.getFcmTokenList()) {
+                String targetToken = fcmToken.getToken();
 
-                    Notification notification = Notification.builder()
-                            .setTitle(title)
-                            .setBody(body)
-                            .build();
+                Notification notification = Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build();
 
-                    Message message = Message.builder()
-                            .setToken(targetToken)
-                            .setNotification(notification)
-                            .build();
+                Message message = Message.builder()
+                        .setToken(targetToken)
+                        .setNotification(notification)
+                        .build();
 
-                    try {
-                        String response = FirebaseMessaging.getInstance().send(message);
-                        log.info("Successfully sent FCM message: {}", response);
-                        recordFcmSuccess();
-                    } catch (Exception e) {
-                        log.error("Error sending FCM message", e);
-                        fcmTokenRepository.deleteByToken(targetToken);
-                        recordFcmFail();
-                    }
+                try {
+                    String response = FirebaseMessaging.getInstance().send(message);
+                    log.info("Successfully sent FCM message: {}", response);
+                    recordFcmSuccess();
+                } catch (Exception e) {
+                    log.error("Error sending FCM message", e);
+                    fcmTokenRepository.deleteByToken(targetToken);
+                    recordFcmFail();
                 }
             }
         }
@@ -138,30 +138,35 @@ public class FcmMessageService {
 
     @Async("fcmExecutor")
     public void sendGroupOrderNotification(User user, String title, String body) {
-        if (!user.getReceiveNotificationTypes().contains(NotificationType.GROUP_ORDER)) {
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!freshUser.getReceiveNotificationTypes().contains(NotificationType.GROUP_ORDER)) {
             return;
         }
 
-        sendMessageToUser(user, title, body);
+        sendMessageToUser(freshUser, title, body);
     }
 
     @Async("fcmExecutor")
     public void sendDormitoryNotification(User user, String title, String body) {
-        if (!user.getReceiveNotificationTypes().contains(NotificationType.DORMITORY)) {
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!freshUser.getReceiveNotificationTypes().contains(NotificationType.DORMITORY)) {
             return;
         }
 
-        sendMessageToUser(user, title, body);
-
+        sendMessageToUser(freshUser, title, body);
     }
 
     @Async("fcmExecutor")
     public void sendUnidormNotification(User user, String title, String body) {
-        if (!user.getReceiveNotificationTypes().contains(NotificationType.UNI_DORM)) {
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!freshUser.getReceiveNotificationTypes().contains(NotificationType.UNI_DORM)) {
             return;
         }
 
-        sendMessageToUser(user, title, body);
+        sendMessageToUser(freshUser, title, body);
     }
 
 /*    private void sendMessageToUser(User user, String title, String body) {
@@ -191,14 +196,15 @@ public class FcmMessageService {
 
     private void sendMessageToUser(User user, String title, String body) {
         log.info("      🚀 sendMessageToUser 시작 (User ID: {})", user.getId());
-        log.info("      📱 FCM Token 리스트 크기: {}", user.getFcmTokenList().size());
+        List<FcmToken> fcmTokens = fcmTokenRepository.findAllByUser(user);
+        log.info("      📱 FCM Token 리스트 크기: {}", fcmTokens.size());
 
         int tokenIndex = 0;
-        for (FcmToken fcmToken : user.getFcmTokenList()) {
+        for (FcmToken fcmToken : fcmTokens) {
             tokenIndex++;
             String targetToken = fcmToken.getToken();
 
-            log.info("      ━━━ Token [{}/{}] ━━━", tokenIndex, user.getFcmTokenList().size());
+            log.info("      ━━━ Token [{}/{}] ━━━", tokenIndex, fcmTokens.size());
             log.info("      Token: {}...", targetToken.substring(0, Math.min(30, targetToken.length())));
 
             Notification notification = Notification.builder()
@@ -258,19 +264,23 @@ public class FcmMessageService {
 
     @Async("fcmExecutor")
     public void sendSupporterNotification(User user, String title, String body) {
-        if (!user.getReceiveNotificationTypes().contains(NotificationType.SUPPORTERS)) {
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!freshUser.getReceiveNotificationTypes().contains(NotificationType.SUPPORTERS)) {
             return;
         }
 
-        sendMessageToUser(user, title, body);
+        sendMessageToUser(freshUser, title, body);
     }
 
     @Async("fcmExecutor")
     public void sendUnidormAnnouncementNotification(User user, String title, String body) {
-        if (!user.getReceiveNotificationTypes().contains(NotificationType.UNI_DORM)) {
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!freshUser.getReceiveNotificationTypes().contains(NotificationType.UNI_DORM)) {
             return;
         }
 
-        sendMessageToUser(user, title, body);
+        sendMessageToUser(freshUser, title, body);
     }
 }

--- a/src/main/java/com/example/appcenter_project/domain/user/repository/FcmTokenRepository.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/repository/FcmTokenRepository.java
@@ -4,12 +4,14 @@ import com.example.appcenter_project.domain.fcm.entity.FcmToken;
 import com.example.appcenter_project.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FcmTokenRepository extends JpaRepository<FcmToken,Long> {
     void deleteByToken(String targetToken);
     boolean existsByToken(String token);
     Optional<FcmToken> findByUser(User user);
+    List<FcmToken> findAllByUser(User user);
 
     FcmToken findByToken(String token);
 }

--- a/src/main/java/com/example/appcenter_project/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/repository/UserRepository.java
@@ -37,6 +37,15 @@ public interface UserRepository extends JpaRepository<User, Long> {
             @Param("excludedRoles") List<Role> excludedRoles
     );
 
+    @Query("SELECT DISTINCT u FROM User u " +
+            "LEFT JOIN FETCH u.fcmTokenList " +
+            "WHERE u.dormType != :dormType " +
+            "AND :notificationType MEMBER OF u.receiveNotificationTypes")
+    List<User> findDormitoryUsersWithFcmTokens(
+            @Param("dormType") DormType dormType,
+            @Param("notificationType") NotificationType notificationType
+    );
+
     @Query("SELECT u FROM User u " +
             "WHERE u.dormType != :dormType " +
             "AND :notificationType MEMBER OF u.receiveNotificationTypes " +


### PR DESCRIPTION
## 개요
`@Async` 메서드에서 `User.fcmTokenList`(Lazy `@OneToMany`)와 `User.receiveNotificationTypes`(Lazy `@ElementCollection`)에
직접 접근 시 Hibernate Session이 없어 `LazyInitializationException`이 발생하는 문제를 수정한다.
`FcmTokenRepository` 직접 조회와 JOIN FETCH 쿼리로 Lazy 컬렉션 접근을 제거한다.

## 변경 사항
- [Repository] `FcmTokenRepository.findAllByUser()` 추가 - Lazy 컬렉션 우회용 직접 조회 (c028a73)
- [Repository] `UserRepository.findDormitoryUsersWithFcmTokens()` 추가 - fcmTokenList JOIN FETCH + receiveNotificationTypes 필터 (c028a73)
- [Service] `FcmMessageService.sendNotification()` - `getFcmTokenList()` → `fcmTokenRepository.findAllByUser()` 교체 (c028a73)
- [Service] `FcmMessageService.sendMessageToUser()` - 동일하게 교체 (sendDormitoryNotification 등 모든 @Async 메서드 해결) (c028a73)
- [Service] `FcmMessageService.sendNotificationDormitoryPerson()` - JOIN FETCH 쿼리로 receiveNotificationTypes/fcmTokenList lazy 접근 제거 (c028a73)

## 테스트
- [ ] 로컬 빌드 확인 (`./gradlew build`)
- [ ] FCM 알림 전송 시 LazyInitializationException 미발생 확인
- [ ] 기숙사 대상 FCM 알림 전송 정상 동작 확인

closes #579