### PR TITLE
0403(다중기기 로그인, fcm lazy)

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -10,6 +10,7 @@
 | 2026-03-29 | [#555](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/555) | 룸메이트 채팅방 입장 중 알림 차단 | teach/fix/roommate-chat-notification-555 | 채팅방 입장 중 알림 DB+FCM 생략 |
 | 2026-03-29 | [#557](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/557) | FCM 알림 다중 기기 지원 및 비동기 처리 개선 | teach/refactor/fcm-notification-improvement-557 | 다중 기기 전송, 실패 토큰 정리, @Async 처리 |
 | 2026-03-30 | [#561](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/561) | Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화 | teach/test/testcontainers-integration-test-561 | Oracle MockBean, MySQL/Redis 컨테이너, Gradle 캐시 |
+| 2026-04-03 | [#577](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/577) | Refresh Token Rotation 적용 | teach/fix/refresh-token-rotation-577 | 재발급 시 기존 RefreshToken 삭제 후 새 토큰 함께 발급 |
 
 ## 완료된 이슈
 
@@ -22,3 +23,4 @@
 - [x] #568 [docs] 알림 API Swagger notificationType 유효 값 명시 → PR #569 merged
 - [x] #570 [refactor] 개인 알림 전송 API 통합 및 notificationType Swagger 문서화 → PR #571 merged
 - [x] #572 [feat] ADMIN 특정 유저 Role 변경 기능 → PR #573 merged
+- [x] #577 [fix] Refresh Token Rotation 적용으로 다중 기기 토큰 갱신 보안 강화 → PR #578 merged

--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -11,6 +11,7 @@
 | 2026-03-29 | [#557](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/557) | FCM 알림 다중 기기 지원 및 비동기 처리 개선 | teach/refactor/fcm-notification-improvement-557 | 다중 기기 전송, 실패 토큰 정리, @Async 처리 |
 | 2026-03-30 | [#561](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/561) | Testcontainers 통합 테스트 환경 구축 및 CI 빌드 최적화 | teach/test/testcontainers-integration-test-561 | Oracle MockBean, MySQL/Redis 컨테이너, Gradle 캐시 |
 | 2026-04-03 | [#577](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/577) | Refresh Token Rotation 적용 | teach/fix/refresh-token-rotation-577 | 재발급 시 기존 RefreshToken 삭제 후 새 토큰 함께 발급 |
+| 2026-04-03 | [#579](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/579) | FcmMessageService @Async LazyInitializationException 수정 | teach/fix/fcm-lazy-init-579 | @Async 메서드에서 Lazy 컬렉션 직접 접근 제거 |
 
 ## 완료된 이슈
 
@@ -24,3 +25,4 @@
 - [x] #570 [refactor] 개인 알림 전송 API 통합 및 notificationType Swagger 문서화 → PR #571 merged
 - [x] #572 [feat] ADMIN 특정 유저 Role 변경 기능 → PR #573 merged
 - [x] #577 [fix] Refresh Token Rotation 적용으로 다중 기기 토큰 갱신 보안 강화 → PR #578 merged
+- [x] #579 [fix] FcmMessageService @Async 메서드 LazyInitializationException 수정 → PR #580 merged

--- a/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmMessageService.java
+++ b/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmMessageService.java
@@ -37,10 +37,11 @@ public class FcmMessageService {
     private final UserRepository userRepository;
     private final RedisTemplate<String, Object> redisTemplate;
 
-    // todo User user
     @Async("fcmExecutor")
     public void sendNotification(User user, String title, String body) {
-        for (FcmToken fcmToken : user.getFcmTokenList()) {
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        for (FcmToken fcmToken : fcmTokenRepository.findAllByUser(freshUser)) {
             String targetToken = fcmToken.getToken();
 
             Notification notification = Notification.builder()
@@ -107,30 +108,29 @@ public class FcmMessageService {
 
     @Async("fcmExecutor")
     public void sendNotificationDormitoryPerson(String title, String body) {
-        for (User user : userRepository.findByDormTypeNot(DormType.NONE)) {
-            if (user.getReceiveNotificationTypes().contains(NotificationType.DORMITORY)) {
-                for (FcmToken fcmToken : user.getFcmTokenList()) {
-                    String targetToken = fcmToken.getToken();
+        List<User> dormitoryUsers = userRepository.findDormitoryUsersWithFcmTokens(DormType.NONE, NotificationType.DORMITORY);
+        for (User user : dormitoryUsers) {
+            for (FcmToken fcmToken : user.getFcmTokenList()) {
+                String targetToken = fcmToken.getToken();
 
-                    Notification notification = Notification.builder()
-                            .setTitle(title)
-                            .setBody(body)
-                            .build();
+                Notification notification = Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build();
 
-                    Message message = Message.builder()
-                            .setToken(targetToken)
-                            .setNotification(notification)
-                            .build();
+                Message message = Message.builder()
+                        .setToken(targetToken)
+                        .setNotification(notification)
+                        .build();
 
-                    try {
-                        String response = FirebaseMessaging.getInstance().send(message);
-                        log.info("Successfully sent FCM message: {}", response);
-                        recordFcmSuccess();
-                    } catch (Exception e) {
-                        log.error("Error sending FCM message", e);
-                        fcmTokenRepository.deleteByToken(targetToken);
-                        recordFcmFail();
-                    }
+                try {
+                    String response = FirebaseMessaging.getInstance().send(message);
+                    log.info("Successfully sent FCM message: {}", response);
+                    recordFcmSuccess();
+                } catch (Exception e) {
+                    log.error("Error sending FCM message", e);
+                    fcmTokenRepository.deleteByToken(targetToken);
+                    recordFcmFail();
                 }
             }
         }
@@ -138,30 +138,35 @@ public class FcmMessageService {
 
     @Async("fcmExecutor")
     public void sendGroupOrderNotification(User user, String title, String body) {
-        if (!user.getReceiveNotificationTypes().contains(NotificationType.GROUP_ORDER)) {
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!freshUser.getReceiveNotificationTypes().contains(NotificationType.GROUP_ORDER)) {
             return;
         }
 
-        sendMessageToUser(user, title, body);
+        sendMessageToUser(freshUser, title, body);
     }
 
     @Async("fcmExecutor")
     public void sendDormitoryNotification(User user, String title, String body) {
-        if (!user.getReceiveNotificationTypes().contains(NotificationType.DORMITORY)) {
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!freshUser.getReceiveNotificationTypes().contains(NotificationType.DORMITORY)) {
             return;
         }
 
-        sendMessageToUser(user, title, body);
-
+        sendMessageToUser(freshUser, title, body);
     }
 
     @Async("fcmExecutor")
     public void sendUnidormNotification(User user, String title, String body) {
-        if (!user.getReceiveNotificationTypes().contains(NotificationType.UNI_DORM)) {
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!freshUser.getReceiveNotificationTypes().contains(NotificationType.UNI_DORM)) {
             return;
         }
 
-        sendMessageToUser(user, title, body);
+        sendMessageToUser(freshUser, title, body);
     }
 
 /*    private void sendMessageToUser(User user, String title, String body) {
@@ -191,14 +196,15 @@ public class FcmMessageService {
 
     private void sendMessageToUser(User user, String title, String body) {
         log.info("      🚀 sendMessageToUser 시작 (User ID: {})", user.getId());
-        log.info("      📱 FCM Token 리스트 크기: {}", user.getFcmTokenList().size());
+        List<FcmToken> fcmTokens = fcmTokenRepository.findAllByUser(user);
+        log.info("      📱 FCM Token 리스트 크기: {}", fcmTokens.size());
 
         int tokenIndex = 0;
-        for (FcmToken fcmToken : user.getFcmTokenList()) {
+        for (FcmToken fcmToken : fcmTokens) {
             tokenIndex++;
             String targetToken = fcmToken.getToken();
 
-            log.info("      ━━━ Token [{}/{}] ━━━", tokenIndex, user.getFcmTokenList().size());
+            log.info("      ━━━ Token [{}/{}] ━━━", tokenIndex, fcmTokens.size());
             log.info("      Token: {}...", targetToken.substring(0, Math.min(30, targetToken.length())));
 
             Notification notification = Notification.builder()
@@ -258,19 +264,23 @@ public class FcmMessageService {
 
     @Async("fcmExecutor")
     public void sendSupporterNotification(User user, String title, String body) {
-        if (!user.getReceiveNotificationTypes().contains(NotificationType.SUPPORTERS)) {
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!freshUser.getReceiveNotificationTypes().contains(NotificationType.SUPPORTERS)) {
             return;
         }
 
-        sendMessageToUser(user, title, body);
+        sendMessageToUser(freshUser, title, body);
     }
 
     @Async("fcmExecutor")
     public void sendUnidormAnnouncementNotification(User user, String title, String body) {
-        if (!user.getReceiveNotificationTypes().contains(NotificationType.UNI_DORM)) {
+        User freshUser = userRepository.findById(user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!freshUser.getReceiveNotificationTypes().contains(NotificationType.UNI_DORM)) {
             return;
         }
 
-        sendMessageToUser(user, title, body);
+        sendMessageToUser(freshUser, title, body);
     }
 }

--- a/src/main/java/com/example/appcenter_project/domain/user/controller/UserApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/controller/UserApiSpecification.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -75,12 +74,12 @@ public interface UserApiSpecification {
             @Parameter(description = "신입생 로그인 정보", required = true) SignupUser signupUser);
 
     @Operation(
-            summary = "액세스 토큰 재발급",
-            description = "유효한 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.",
+            summary = "액세스 토큰 재발급 (Refresh Token Rotation)",
+            description = "유효한 리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 함께 발급받습니다. 기존 리프레시 토큰은 즉시 무효화되므로, 응답으로 받은 새 리프레시 토큰을 저장해야 합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
                             content = @Content(mediaType = "application/json",
-                                    examples = @ExampleObject(value = "{\"accessToken\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...\"}"))),
+                                    schema = @Schema(implementation = ResponseLoginDto.class))),
                     @ApiResponse(responseCode = "401",
                             description = "유효하지 않은 Refresh Token입니다. (INVALID_REFRESH_TOKEN)",
                             content = @Content(examples = {})),
@@ -90,7 +89,7 @@ public interface UserApiSpecification {
                     )
             }
     )
-    ResponseEntity<?> reissueAccessToken(
+    ResponseEntity<ResponseLoginDto> reissueAccessToken(
             @RequestBody
             @Parameter RequestTokenDto requestTokenDto
     );

--- a/src/main/java/com/example/appcenter_project/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/controller/UserController.java
@@ -7,7 +7,6 @@ import com.example.appcenter_project.domain.user.dto.response.ResponseBoardDto;
 import com.example.appcenter_project.domain.user.dto.response.ResponseLoginDto;
 import com.example.appcenter_project.domain.user.dto.response.ResponseUserDto;
 import com.example.appcenter_project.domain.user.dto.response.ResponseUserRole;
-import com.example.appcenter_project.global.exception.CustomException;
 import com.example.appcenter_project.global.security.CustomUserDetails;
 import com.example.appcenter_project.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -24,7 +23,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.springframework.http.HttpStatus.*;
 
@@ -53,13 +51,8 @@ public class UserController implements UserApiSpecification {
     }
 
     @PostMapping("/refreshToken")
-    public ResponseEntity<?> reissueAccessToken(@RequestBody RequestTokenDto request) {
-        try {
-            String newAccessToken = userService.reissueAccessToken(request);
-            return ResponseEntity.ok(Map.of("accessToken", newAccessToken));
-        } catch (IllegalArgumentException | CustomException e) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
-        }
+    public ResponseEntity<ResponseLoginDto> reissueAccessToken(@RequestBody RequestTokenDto request) {
+        return ResponseEntity.ok(userService.reissueAccessToken(request));
     }
 
     @PostMapping("/push-notification")

--- a/src/main/java/com/example/appcenter_project/domain/user/repository/FcmTokenRepository.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/repository/FcmTokenRepository.java
@@ -4,12 +4,14 @@ import com.example.appcenter_project.domain.fcm.entity.FcmToken;
 import com.example.appcenter_project.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FcmTokenRepository extends JpaRepository<FcmToken,Long> {
     void deleteByToken(String targetToken);
     boolean existsByToken(String token);
     Optional<FcmToken> findByUser(User user);
+    List<FcmToken> findAllByUser(User user);
 
     FcmToken findByToken(String token);
 }

--- a/src/main/java/com/example/appcenter_project/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/repository/UserRepository.java
@@ -37,6 +37,15 @@ public interface UserRepository extends JpaRepository<User, Long> {
             @Param("excludedRoles") List<Role> excludedRoles
     );
 
+    @Query("SELECT DISTINCT u FROM User u " +
+            "LEFT JOIN FETCH u.fcmTokenList " +
+            "WHERE u.dormType != :dormType " +
+            "AND :notificationType MEMBER OF u.receiveNotificationTypes")
+    List<User> findDormitoryUsersWithFcmTokens(
+            @Param("dormType") DormType dormType,
+            @Param("notificationType") NotificationType notificationType
+    );
+
     @Query("SELECT u FROM User u " +
             "WHERE u.dormType != :dormType " +
             "AND :notificationType MEMBER OF u.receiveNotificationTypes " +

--- a/src/main/java/com/example/appcenter_project/domain/user/service/UserService.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/service/UserService.java
@@ -73,7 +73,7 @@ public class UserService {
         return createDto(user);
     }
 
-    public String reissueAccessToken(RequestTokenDto request) {
+    public ResponseLoginDto reissueAccessToken(RequestTokenDto request) {
         validateRefreshToken(request.getRefreshToken());
         String refreshToken = extractBearerToken(request);
         return reissueAccessTokenByRefreshToken(refreshToken);
@@ -279,7 +279,7 @@ public class UserService {
 
     private void validateRefreshToken(String token) {
         if (token == null || !token.startsWith("Bearer ")) {
-            throw new IllegalArgumentException("Refresh Token이 유효하지 않습니다.");
+            throw new CustomException(INVALID_REFRESH_TOKEN);
         }
     }
 
@@ -287,7 +287,7 @@ public class UserService {
         return request.getRefreshToken().substring(7);
     }
 
-    private String reissueAccessTokenByRefreshToken(String refreshToken) {
+    private ResponseLoginDto reissueAccessTokenByRefreshToken(String refreshToken) {
         if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
             throw new CustomException(INVALID_REFRESH_TOKEN);
         }
@@ -296,7 +296,12 @@ public class UserService {
                 .orElseThrow(() -> new CustomException(REFRESH_TOKEN_USER_NOT_FOUND));
         User user = refreshTokenEntity.getUser();
 
-        return jwtTokenProvider.generateAccessToken(user.getId(), user.getStudentNumber(), String.valueOf(user.getRole()));
+        refreshTokenRepository.delete(refreshTokenEntity);
+
+        String newAccessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getStudentNumber(), String.valueOf(user.getRole()));
+        String newRefreshToken = createRefreshToken(user);
+
+        return new ResponseLoginDto(newAccessToken, newRefreshToken, user.getRole().toString());
     }
 
     private void sendMessageToUsers(List<User> userIds, String title, String body) {


### PR DESCRIPTION
  PR #578 — Refresh Token Rotation
  - 제목: Merge: fix: Refresh Token Rotation 적용으로 다중 기기 토큰 갱신 보안    
  강화 #577                                                       
  - 내용: Access Token 재발급 시 기존 Refresh Token이 DB에 유지되어 rotation이
  적용되지 않는 문제 수정. 재발급 시 기존 토큰 삭제 + 새 토큰 발급으로 각 기기가
  독립적인 토큰 체인 유지.
  - 변경: UserService.reissueAccessTokenByRefreshToken() rotation 로직, 반환 타입
  String → ResponseLoginDto, Controller 응답 수정, Swagger 업데이트

  ---
  PR #580 — FCM LazyInitializationException
  - 제목: Merge: fix: FcmMessageService @Async 메서드 LazyInitializationException
  수정 #579
  - 내용: @Async 메서드에서 User.fcmTokenList(Lazy @OneToMany)와
  User.receiveNotificationTypes(Lazy @ElementCollection) 직접 접근 시 Hibernate
  Session 없어 예외 발생. FcmTokenRepository 직접 조회와 JOIN FETCH 쿼리로 Lazy
  접근 제거.
  - 변경: FcmTokenRepository.findAllByUser() 추가,
  UserRepository.findDormitoryUsersWithFcmTokens() JOIN FETCH 쿼리 추가,
  FcmMessageService 3곳 수정
