### PR TITLE
feat: 쿠폰 엔드포인트 Redis Rate Limiting 적용 및 부하 테스트 스크립트 #584

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -13,6 +13,7 @@
 | 2026-04-03 | [#577](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/577) | Refresh Token Rotation 적용 | teach/fix/refresh-token-rotation-577 | 재발급 시 기존 RefreshToken 삭제 후 새 토큰 함께 발급 |
 | 2026-04-03 | [#579](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/579) | FcmMessageService @Async LazyInitializationException 수정 | teach/fix/fcm-lazy-init-579 | @Async 메서드에서 Lazy 컬렉션 직접 접근 제거 |
 | 2026-04-04 | [#582](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/582) | @Async 비동기 스레드 MDC traceId 전파 (TaskDecorator) | teach/chore/mdc-task-decorator-582 | MdcTaskDecorator로 fcmExecutor·asyncExecutor MDC 전파 |
+| 2026-04-04 | [#584](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/584) | 쿠폰 엔드포인트 Redis Rate Limiting 적용 및 부하 테스트 검증 | teach/feat/coupon-rate-limit-584 | @RateLimit AOP + nGrinder Before/After 측정 |
 
 ## 완료된 이슈
 

--- a/docs/ngrinder/coupon_ratelimit_test.groovy
+++ b/docs/ngrinder/coupon_ratelimit_test.groovy
@@ -1,0 +1,111 @@
+/**
+ * nGrinder 부하 테스트 스크립트 - 쿠폰 Rate Limit 전/후 비교
+ *
+ * ===== 사전 준비 =====
+ * 1. nGrinder 설치 및 실행
+ *    - Docker: docker run -d -p 8300:8080 ngrinder/controller:latest
+ *    - http://localhost:8300 접속 (admin/admin)
+ *
+ * 2. Agent 실행 (테스트 트래픽을 실제로 발생시키는 프로세스)
+ *    - nGrinder 대시보드 → Agent Management → Download Agent
+ *    - 압축 해제 후: ./run_agent.sh 실행
+ *
+ * 3. 테스트 계정 JWT 토큰 준비
+ *    - POST /users/login 으로 로그인 → accessToken 복사
+ *    - 아래 BEARER_TOKEN 변수에 붙여넣기
+ *
+ * ===== 테스트 시나리오 =====
+ * [Before] Rate Limit 없는 상태에서 100 vUser 동시 요청
+ *    → DB 쿼리 수, 응답 시간 P99 측정
+ *
+ * [After] Rate Limit 적용 후 동일 시나리오
+ *    → 429 차단 비율, DB 쿼리 수 감소량 측정
+ *
+ * ===== nGrinder 설정값 =====
+ * - vUser: 100
+ * - Duration: 30초
+ * - Ramp-up: 10초 (0 → 100 vUser 점진적 증가)
+ * - Target URL: http://{서버IP}:8055/coupons
+ *
+ * ===== 측정 지표 =====
+ * - TPS (Transactions Per Second)
+ * - Mean Response Time (ms)
+ * - P99 Response Time (ms)
+ * - 429 응답 비율 (= 차단된 요청 비율)
+ *
+ * ===== DB 쿼리 수 측정 방법 =====
+ * MySQL slow query log 또는 Prometheus + Spring Actuator 사용:
+ *   # 테스트 전 카운터 초기화
+ *   SELECT variable_value FROM performance_schema.global_status WHERE variable_name = 'Com_select';
+ *
+ *   # 테스트 후 카운터 재조회 → 차이값 = 테스트 중 SELECT 쿼리 수
+ *   SELECT variable_value FROM performance_schema.global_status WHERE variable_name = 'Com_select';
+ */
+
+import static net.grinder.script.Grinder.grinder
+import static org.junit.Assert.*
+import net.grinder.script.GTest
+import net.grinder.scriptengine.groovy.junit.GrinderRunner
+import net.grinder.scriptengine.groovy.junit.annotation.RunWith
+import net.grinder.scriptengine.groovy.junit.annotation.BeforeProcess
+import net.grinder.scriptengine.groovy.junit.annotation.BeforeThread
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith as JUnitRunWith
+
+import HTTPClient.HTTPResponse
+import HTTPClient.NVPair
+
+@RunWith(GrinderRunner)
+class CouponRateLimitTest {
+
+    // ===== 설정값 — 실행 전 반드시 변경 =====
+    static final String BASE_URL = "http://localhost:8055"
+    static final String BEARER_TOKEN = "Bearer {여기에_JWT_accessToken_입력}"
+    // ==========================================
+
+    static GTest test
+    static HTTPClient.HTTPConnection connection
+
+    @BeforeProcess
+    static void beforeProcess() {
+        test = new GTest(1, "GET /coupons")
+        connection = new HTTPClient.HTTPConnection(BASE_URL)
+        grinder.logger.info("테스트 초기화 완료 - Target: ${BASE_URL}")
+    }
+
+    @BeforeThread
+    void beforeThread() {
+        test.record(this, "request")
+        grinder.statistics.delayReports = true
+    }
+
+    @Before
+    void before() {
+        grinder.logger.info("vUser ${grinder.threadNumber} 시작")
+    }
+
+    @Test
+    void request() {
+        NVPair[] headers = [
+            new NVPair("Authorization", BEARER_TOKEN),
+            new NVPair("Content-Type", "application/json")
+        ]
+
+        HTTPResponse response = connection.Get("/coupons", null, headers)
+
+        int statusCode = response.statusCode
+
+        // 200 (성공) 또는 429 (Rate Limit 차단) 만 허용
+        // Rate Limit 없을 때는 200/기타만 나옴
+        if (statusCode == 200) {
+            grinder.logger.info("vUser ${grinder.threadNumber} → 200 OK (쿠폰 발급 처리)")
+        } else if (statusCode == 429) {
+            grinder.logger.info("vUser ${grinder.threadNumber} → 429 Rate Limit 차단")
+        } else {
+            grinder.logger.warn("vUser ${grinder.threadNumber} → ${statusCode} (예상치 못한 응답)")
+        }
+
+        assertTrue("응답 코드는 200 또는 429여야 합니다", statusCode == 200 || statusCode == 429)
+    }
+}

--- a/src/main/java/com/example/appcenter_project/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/appcenter_project/domain/coupon/controller/CouponController.java
@@ -1,6 +1,7 @@
 package com.example.appcenter_project.domain.coupon.controller;
 
 import com.example.appcenter_project.domain.coupon.dto.response.ResponseCouponDto;
+import com.example.appcenter_project.global.ratelimit.annotation.RateLimit;
 import com.example.appcenter_project.global.security.CustomUserDetails;
 import com.example.appcenter_project.domain.coupon.service.CouponService;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.concurrent.TimeUnit;
+
 @RestController
 @RequestMapping("/coupons")
 @RequiredArgsConstructor
@@ -17,6 +20,7 @@ public class CouponController {
 
     private final CouponService couponService;
 
+    @RateLimit(limit = 1, window = 5, unit = TimeUnit.SECONDS)
     @GetMapping
     public ResponseEntity<ResponseCouponDto> findCoupon(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(couponService.findCoupon(userDetails.getId()));

--- a/src/main/java/com/example/appcenter_project/global/ratelimit/annotation/RateLimit.java
+++ b/src/main/java/com/example/appcenter_project/global/ratelimit/annotation/RateLimit.java
@@ -1,0 +1,20 @@
+package com.example.appcenter_project.global.ratelimit.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimit {
+
+    int limit() default 1;
+
+    long window() default 5;
+
+    TimeUnit unit() default TimeUnit.SECONDS;
+
+    String keyPrefix() default "rate_limit";
+}

--- a/src/main/java/com/example/appcenter_project/global/ratelimit/aspect/RateLimitAspect.java
+++ b/src/main/java/com/example/appcenter_project/global/ratelimit/aspect/RateLimitAspect.java
@@ -1,0 +1,60 @@
+package com.example.appcenter_project.global.ratelimit.aspect;
+
+import com.example.appcenter_project.global.exception.CustomException;
+import com.example.appcenter_project.global.exception.ErrorCode;
+import com.example.appcenter_project.global.ratelimit.annotation.RateLimit;
+import com.example.appcenter_project.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class RateLimitAspect {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Around("@annotation(com.example.appcenter_project.global.ratelimit.annotation.RateLimit)")
+    public Object checkRateLimit(ProceedingJoinPoint joinPoint) throws Throwable {
+        Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+        RateLimit rateLimit = method.getAnnotation(RateLimit.class);
+
+        String userId = resolveUserId();
+        String redisKey = rateLimit.keyPrefix() + ":" + joinPoint.getSignature().getName() + ":" + userId;
+
+        long windowSeconds = rateLimit.unit().toSeconds(rateLimit.window());
+
+        Long count = redisTemplate.opsForValue().increment(redisKey);
+
+        if (count != null && count == 1) {
+            redisTemplate.expire(redisKey, windowSeconds, TimeUnit.SECONDS);
+        }
+
+        if (count != null && count > rateLimit.limit()) {
+            log.warn("[RateLimit] 요청 횟수 초과 - key: {}, count: {}", redisKey, count);
+            throw new CustomException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        }
+
+        return joinPoint.proceed();
+    }
+
+    private String resolveUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+            return userDetails.getId().toString();
+        }
+        return "anonymous";
+    }
+}

--- a/src/test/java/com/example/appcenter_project/global/ratelimit/RateLimitAspectTest.java
+++ b/src/test/java/com/example/appcenter_project/global/ratelimit/RateLimitAspectTest.java
@@ -1,0 +1,108 @@
+package com.example.appcenter_project.global.ratelimit;
+
+import com.example.appcenter_project.global.exception.CustomException;
+import com.example.appcenter_project.global.exception.ErrorCode;
+import com.example.appcenter_project.global.ratelimit.aspect.RateLimitAspect;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RateLimitAspectTest {
+
+    @InjectMocks
+    private RateLimitAspect rateLimitAspect;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private ProceedingJoinPoint joinPoint;
+
+    @Mock
+    private MethodSignature methodSignature;
+
+    @BeforeEach
+    void setUp() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(joinPoint.getSignature()).willReturn(methodSignature);
+        given(methodSignature.getName()).willReturn("findCoupon");
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("첫 번째 요청은 정상 처리된다")
+    void first_request_passes() throws Throwable {
+        Method method = SampleController.class.getMethod("findCoupon");
+        given(methodSignature.getMethod()).willReturn(method);
+        given(valueOperations.increment(anyString())).willReturn(1L);
+        given(joinPoint.proceed()).willReturn("OK");
+
+        Object result = rateLimitAspect.checkRateLimit(joinPoint);
+
+        assertThat(result).isEqualTo("OK");
+        verify(redisTemplate).expire(anyString(), eq(5L), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    @DisplayName("limit 초과 요청은 RATE_LIMIT_EXCEEDED 예외가 발생한다")
+    void exceed_limit_throws_exception() throws Throwable {
+        Method method = SampleController.class.getMethod("findCoupon");
+        given(methodSignature.getMethod()).willReturn(method);
+        given(valueOperations.increment(anyString())).willReturn(2L); // limit=1 초과
+
+        assertThatThrownBy(() -> rateLimitAspect.checkRateLimit(joinPoint))
+                .isInstanceOf(CustomException.class)
+                .satisfies(e -> assertThat(((CustomException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.RATE_LIMIT_EXCEEDED));
+
+        verify(joinPoint, never()).proceed();
+    }
+
+    @Test
+    @DisplayName("두 번째 요청부터는 Redis TTL을 새로 설정하지 않는다")
+    void no_expire_reset_after_first_request() throws Throwable {
+        Method method = SampleController.class.getMethod("findCoupon");
+        given(methodSignature.getMethod()).willReturn(method);
+        given(valueOperations.increment(anyString())).willReturn(2L);
+
+        assertThatThrownBy(() -> rateLimitAspect.checkRateLimit(joinPoint))
+                .isInstanceOf(CustomException.class);
+
+        verify(redisTemplate, never()).expire(anyString(), anyLong(), any());
+    }
+
+    /**
+     * @RateLimit 어노테이션이 붙은 메서드를 테스트 대역으로 사용
+     */
+    static class SampleController {
+        @com.example.appcenter_project.global.ratelimit.annotation.RateLimit(limit = 1, window = 5, unit = TimeUnit.SECONDS)
+        public String findCoupon() {
+            return "OK";
+        }
+    }
+}


### PR DESCRIPTION
## 개요

이벤트 쿠폰 오픈 시 매크로 기반 반복 요청이 DB 비관적 락까지 전달되어 불필요한 락 경합이 발생하는 문제를 해결한다.
Spring AOP + Redis INCR/EXPIRE Fixed Window 패턴으로 `@RateLimit` 어노테이션을 구현하여 사용자별 요청 빈도를 제어한다.
nGrinder 부하 테스트 스크립트로 Rate Limit 적용 전/후 DB 쿼리 수와 응답 시간을 비교할 수 있다.

## 변경 사항

- [어노테이션] `@RateLimit(limit, window, unit, keyPrefix)` 커스텀 어노테이션 추가
- [AOP] `RateLimitAspect` — Redis INCR+EXPIRE Fixed Window로 limit 초과 시 429 반환
- [컨트롤러] `CouponController.findCoupon()` — `@RateLimit(limit=1, window=5, unit=SECONDS)` 적용
- [예외] `ErrorCode.RATE_LIMIT_EXCEEDED` → HTTP 429 응답
- [테스트] `RateLimitAspectTest` — 단위 테스트 3건 (첫 요청 통과, limit 초과 차단, TTL 재설정 방지)
- [부하테스트] `docs/ngrinder/coupon_ratelimit_test.groovy` — 100 vUser, 30s, Before/After 시나리오

## 방어 계층 구조

```
[1계층] @RateLimit AOP — 사용자별 5초 1회 제한 (Redis Fixed Window)
    └─ [2계층] DB 비관적 락 — 실제 발급 처리
```

## 테스트

- [x] 로컬 빌드 확인 (`./gradlew build`)
- [x] `RateLimitAspectTest` 3건 통과
- [ ] nGrinder Before/After 부하 테스트 수치 측정

closes #584