### PR TITLE
feat: 쿠폰 다중 방어 기제 구현 (Rate Limiting + Redis 잔여 수 캐시) #584 #585

### DIFF
--- a/src/main/java/com/example/appcenter_project/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/appcenter_project/domain/coupon/controller/CouponController.java
@@ -1,15 +1,15 @@
 package com.example.appcenter_project.domain.coupon.controller;
 
+import com.example.appcenter_project.domain.coupon.dto.request.RequestSetCouponStockDto;
 import com.example.appcenter_project.domain.coupon.dto.response.ResponseCouponDto;
 import com.example.appcenter_project.global.ratelimit.annotation.RateLimit;
 import com.example.appcenter_project.global.security.CustomUserDetails;
 import com.example.appcenter_project.domain.coupon.service.CouponService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.concurrent.TimeUnit;
 
@@ -24,5 +24,11 @@ public class CouponController {
     @GetMapping
     public ResponseEntity<ResponseCouponDto> findCoupon(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(couponService.findCoupon(userDetails.getId()));
+    }
+
+    @PostMapping("/admin/stock")
+    public ResponseEntity<Void> setStock(@Valid @RequestBody RequestSetCouponStockDto request) {
+        couponService.setStock(request.count());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/appcenter_project/domain/coupon/dto/request/RequestSetCouponStockDto.java
+++ b/src/main/java/com/example/appcenter_project/domain/coupon/dto/request/RequestSetCouponStockDto.java
@@ -1,0 +1,9 @@
+package com.example.appcenter_project.domain.coupon.dto.request;
+
+import jakarta.validation.constraints.Min;
+
+public record RequestSetCouponStockDto(
+        @Min(value = 0, message = "쿠폰 수량은 0 이상이어야 합니다.")
+        int count
+) {
+}

--- a/src/main/java/com/example/appcenter_project/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/appcenter_project/domain/coupon/service/CouponService.java
@@ -33,6 +33,7 @@ import java.time.format.DateTimeFormatter;
 public class CouponService {
 
     private static final String REDIS_KEY = "coupon_date_time";
+    private static final String REDIS_STOCK_KEY = "coupon_stock";
 
     private final CouponRepository couponRepository;
     private final NotificationRepository notificationRepository;
@@ -57,6 +58,11 @@ public class CouponService {
         if (isAlreadyHaveCoupon(userId)) {
             log.info("사용자 {}는 이미 쿠폰을 발급받았습니다.", userId);
             return ResponseCouponDto.of(true, true);
+        }
+
+        if (isStockDepletedByCache()) {
+            log.info("쿠폰 소진 (Redis 캐시 hit) - DB 조회 차단 - userId: {}", userId);
+            return ResponseCouponDto.of(false, false);
         }
 
         if (isNotExistsCoupon()) {
@@ -111,6 +117,7 @@ public class CouponService {
             createUserNotification(user, notification);
 
             couponRepository.delete(coupon);
+            decrementStockCache();
 
             log.info("쿠폰 발급 성공 - userId: {}, couponId: {}", userId, coupon.getId());
             return ResponseCouponDto.of(true, false);
@@ -124,7 +131,31 @@ public class CouponService {
         }
     }
 
+    public void setStock(int count) {
+        redisTemplate.opsForValue().set(REDIS_STOCK_KEY, String.valueOf(count));
+        log.info("쿠폰 잔여 수 Redis 초기화 - count: {}", count);
+    }
+
     // ========== Private Methods ========== //
+
+    private boolean isStockDepletedByCache() {
+        try {
+            String stockStr = redisTemplate.opsForValue().get(REDIS_STOCK_KEY);
+            if (stockStr == null) return false;
+            return Long.parseLong(stockStr) <= 0;
+        } catch (Exception e) {
+            log.warn("Redis 잔여 수 확인 실패, DB 조회로 fallback: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private void decrementStockCache() {
+        try {
+            redisTemplate.opsForValue().decrement(REDIS_STOCK_KEY);
+        } catch (Exception e) {
+            log.warn("Redis 쿠폰 잔여 수 DECR 실패: {}", e.getMessage());
+        }
+    }
 
     private String getCouponOpenTime() {
         try {

--- a/src/main/java/com/example/appcenter_project/domain/groupOrder/repository/GroupOrderCommentRepository.java
+++ b/src/main/java/com/example/appcenter_project/domain/groupOrder/repository/GroupOrderCommentRepository.java
@@ -2,6 +2,8 @@ package com.example.appcenter_project.domain.groupOrder.repository;
 
 import com.example.appcenter_project.domain.groupOrder.entity.GroupOrderComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +12,7 @@ public interface GroupOrderCommentRepository extends JpaRepository<GroupOrderCom
     List<GroupOrderComment> findByGroupOrder_Id(Long groupOrderId);
     List<GroupOrderComment> findByGroupOrderIdAndParentGroupOrderCommentIsNull(Long groupOrderId);
     Optional<GroupOrderComment> findByIdAndUserId(Long id, Long userId);
+
+    @Query("SELECT c FROM GroupOrderComment c WHERE c.groupOrder.id IN :groupOrderIds")
+    List<GroupOrderComment> findByGroupOrderIds(@Param("groupOrderIds") List<Long> groupOrderIds);
 }

--- a/src/main/java/com/example/appcenter_project/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/appcenter_project/global/config/SecurityConfig.java
@@ -152,6 +152,7 @@ public class SecurityConfig {
                         .requestMatchers("/fcm/token/**").permitAll()
 
                         /** 쿠폰 **/
+                        .requestMatchers(POST, "/coupons/admin/stock").hasRole("ADMIN")
                         .requestMatchers("/coupons/**").authenticated()
 
                         /** 설문조사 **/

--- a/src/test/java/com/example/appcenter_project/domain/coupon/service/CouponStockCacheTest.java
+++ b/src/test/java/com/example/appcenter_project/domain/coupon/service/CouponStockCacheTest.java
@@ -1,0 +1,120 @@
+package com.example.appcenter_project.domain.coupon.service;
+
+import com.example.appcenter_project.domain.coupon.dto.response.ResponseCouponDto;
+import com.example.appcenter_project.domain.coupon.entity.Coupon;
+import com.example.appcenter_project.domain.coupon.repository.CouponRepository;
+import com.example.appcenter_project.domain.notification.repository.NotificationRepository;
+import com.example.appcenter_project.domain.notification.repository.UserNotificationRepository;
+import com.example.appcenter_project.domain.user.entity.User;
+import com.example.appcenter_project.domain.user.enums.NotificationType;
+import com.example.appcenter_project.domain.user.enums.Role;
+import com.example.appcenter_project.domain.user.repository.UserRepository;
+import com.example.appcenter_project.global.cache.CouponLocalCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CouponStockCacheTest {
+
+    @InjectMocks
+    private CouponService couponService;
+
+    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private ValueOperations<String, String> valueOperations;
+    @Mock private UserRepository userRepository;
+    @Mock private CouponRepository couponRepository;
+    @Mock private UserNotificationRepository userNotificationRepository;
+    @Mock private NotificationRepository notificationRepository;
+    @Mock private CouponLocalCache couponLocalCache;
+
+    @BeforeEach
+    void setUp() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("Redis 잔여 수가 0이면 DB 조회 없이 즉시 반환한다")
+    void stock_depleted_in_cache_skips_db() {
+        User user = mock(User.class);
+        given(user.getRole()).willReturn(Role.ROLE_USER);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userNotificationRepository.existsByUserIdAndNotificationType(1L, NotificationType.COUPON))
+                .willReturn(false);
+        given(valueOperations.get("coupon_stock")).willReturn("0");
+
+        ResponseCouponDto result = couponService.findCoupon(1L);
+
+        assertThat(result.isSuccess()).isFalse();
+        verify(couponRepository, never()).count();
+    }
+
+    @Test
+    @DisplayName("Redis 잔여 수가 음수이면 DB 조회 없이 즉시 반환한다")
+    void negative_stock_cache_skips_db() {
+        User user = mock(User.class);
+        given(user.getRole()).willReturn(Role.ROLE_USER);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userNotificationRepository.existsByUserIdAndNotificationType(1L, NotificationType.COUPON))
+                .willReturn(false);
+        given(valueOperations.get("coupon_stock")).willReturn("-1");
+
+        ResponseCouponDto result = couponService.findCoupon(1L);
+
+        assertThat(result.isSuccess()).isFalse();
+        verify(couponRepository, never()).count();
+    }
+
+    @Test
+    @DisplayName("Redis 캐시 미설정(null)이면 DB 조회로 폴백한다")
+    void null_stock_cache_falls_back_to_db() {
+        User user = mock(User.class);
+        given(user.getRole()).willReturn(Role.ROLE_USER);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userNotificationRepository.existsByUserIdAndNotificationType(1L, NotificationType.COUPON))
+                .willReturn(false);
+        given(valueOperations.get("coupon_stock")).willReturn(null);
+        given(couponRepository.count()).willReturn(0L);
+
+        couponService.findCoupon(1L);
+
+        verify(couponRepository).count();
+    }
+
+    @Test
+    @DisplayName("setStock 호출 시 Redis에 지정한 수량이 저장된다")
+    void set_stock_writes_to_redis() {
+        couponService.setStock(100);
+
+        verify(valueOperations).set("coupon_stock", "100");
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 성공 시 Redis 잔여 수가 감소한다")
+    void successful_issuance_decrements_stock() {
+        User user = mock(User.class);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userNotificationRepository.existsByUserIdAndNotificationType(1L, NotificationType.COUPON))
+                .willReturn(false);
+
+        Coupon coupon = new Coupon();
+        given(couponRepository.findByIdWithLock(1L)).willReturn(Optional.of(coupon));
+
+        couponService.issuanceCoupon(1L, 1L);
+
+        verify(valueOperations).decrement("coupon_stock");
+    }
+}


### PR DESCRIPTION
## 개요

이벤트 쿠폰 오픈 시 매크로 트래픽이 DB 비관적 락 경합을 유발하는 문제를 해결하기 위해 2계층 방어 기제를 구현한다.
Rate Limiting(1계층)으로 사용자별 요청 빈도를 제어하고, Redis 잔여 수 캐시(2계층)로 소진 후 불필요한 DB 조회를 차단한다.

## 변경 사항

**[1계층] Rate Limiting — #584**
- `@RateLimit(limit, window, unit, keyPrefix)` 커스텀 어노테이션
- `RateLimitAspect` — Redis INCR+EXPIRE Fixed Window, limit 초과 시 HTTP 429 반환
- `CouponController.findCoupon()` — `@RateLimit(limit=1, window=5, unit=SECONDS)` 적용
- `ErrorCode.RATE_LIMIT_EXCEEDED` 추가
- `docs/ngrinder/coupon_ratelimit_test.groovy` — 100 vUser Before/After 부하 테스트 스크립트

**[2계층] Redis 잔여 수 캐시 — #585**
- `CouponService.findCoupon()` — `coupon_stock` 캐시 선행 확인, 0 이하면 DB 조회 없이 즉시 반환
- `CouponService.issuanceCoupon()` — 발급 성공 시 Redis 잔여 수 DECR
- `CouponService.setStock()` — Redis 잔여 수 초기값 SET
- `POST /coupons/admin/stock` — ADMIN 전용 쿠폰 수량 초기화 엔드포인트
- `SecurityConfig` — `/coupons/admin/stock` → `hasRole("ADMIN")`

**[테스트]**
- `RateLimitAspectTest` — 단위 테스트 3건
- `CouponStockCacheTest` — 단위 테스트 5건

## 방어 계층 구조

```
요청 인입
  └─ [1계층] @RateLimit AOP — 사용자별 5초 1회 제한 (Redis Fixed Window)
      └─ [2계층] Redis 잔여 수 캐시 — count ≤ 0 시 DB 조회 없이 즉시 반환
          └─ [3계층] DB 비관적 락 — 실제 발급 처리
```

## 테스트

- [x] 로컬 빌드 확인
- [x] 단위 테스트 8건 전부 통과
- [ ] nGrinder Before/After 부하 테스트 수치 측정

closes #584
closes #585