### PR TITLE
feat: 쿠폰 다중 방어 기제 구현 (Redis Rate Limiting + 재고 캐시) #584 #585

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -13,8 +13,6 @@
 | 2026-04-03 | [#577](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/577) | Refresh Token Rotation 적용 | teach/fix/refresh-token-rotation-577 | 재발급 시 기존 RefreshToken 삭제 후 새 토큰 함께 발급 |
 | 2026-04-03 | [#579](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/579) | FcmMessageService @Async LazyInitializationException 수정 | teach/fix/fcm-lazy-init-579 | @Async 메서드에서 Lazy 컬렉션 직접 접근 제거 |
 | 2026-04-04 | [#582](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/582) | @Async 비동기 스레드 MDC traceId 전파 (TaskDecorator) | teach/chore/mdc-task-decorator-582 | MdcTaskDecorator로 fcmExecutor·asyncExecutor MDC 전파 |
-| 2026-04-04 | [#584](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/584) | 쿠폰 엔드포인트 Redis Rate Limiting 적용 및 부하 테스트 검증 | teach/feat/coupon-rate-limit-584 | @RateLimit AOP + nGrinder Before/After 측정 |
-
 ## 완료된 이슈
 
 - [x] #553 [feat] FCM 알림 통계 조회 API → PR #554 merged
@@ -29,3 +27,5 @@
 - [x] #577 [fix] Refresh Token Rotation 적용으로 다중 기기 토큰 갱신 보안 강화 → PR #578 merged
 - [x] #579 [fix] FcmMessageService @Async 메서드 LazyInitializationException 수정 → PR #580 merged
 - [x] #582 [chore] @Async 비동기 스레드 MDC traceId 전파 (TaskDecorator) → PR #583 merged
+- [x] #584 [feat] 쿠폰 엔드포인트 Redis Rate Limiting 적용 → PR #588 merged
+- [x] #585 [feat] 쿠폰 잔여 수 Redis 캐시로 DB 조회 차단 (다중 방어 2계층) → PR #588 merged

--- a/docs/ngrinder/coupon_ratelimit_test.groovy
+++ b/docs/ngrinder/coupon_ratelimit_test.groovy
@@ -3,7 +3,7 @@
  *
  * ===== 사전 준비 =====
  * 1. nGrinder 설치 및 실행
- *    - Docker: docker run -d -p 8300:8080 ngrinder/controller:latest
+ *    - Docker: docker run -d -p 8300:80 -p 16001:16001 -p 12000-12009:12000-12009 ngrinder/controller:latest
  *    - http://localhost:8300 접속 (admin/admin)
  *
  * 2. Agent 실행 (테스트 트래픽을 실제로 발생시키는 프로세스)
@@ -12,7 +12,7 @@
  *
  * 3. 테스트 계정 JWT 토큰 준비
  *    - POST /users/login 으로 로그인 → accessToken 복사
- *    - 아래 BEARER_TOKEN 변수에 붙여넣기
+ *    - 아래 BEARER_TOKEN 변수에 "Bearer {토큰}" 형태로 입력
  *
  * ===== 테스트 시나리오 =====
  * [Before] Rate Limit 없는 상태에서 100 vUser 동시 요청
@@ -43,69 +43,55 @@
  */
 
 import static net.grinder.script.Grinder.grinder
-import static org.junit.Assert.*
 import net.grinder.script.GTest
 import net.grinder.scriptengine.groovy.junit.GrinderRunner
-import net.grinder.scriptengine.groovy.junit.annotation.RunWith
 import net.grinder.scriptengine.groovy.junit.annotation.BeforeProcess
 import net.grinder.scriptengine.groovy.junit.annotation.BeforeThread
-import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith as JUnitRunWith
+import org.junit.runner.RunWith
 
-import HTTPClient.HTTPResponse
+import net.grinder.plugin.http.HTTPRequest
 import HTTPClient.NVPair
 
 @RunWith(GrinderRunner)
 class CouponRateLimitTest {
 
     // ===== 설정값 — 실행 전 반드시 변경 =====
-    static final String BASE_URL = "http://localhost:8055"
-    static final String BEARER_TOKEN = "Bearer {여기에_JWT_accessToken_입력}"
+    static final String TARGET_URL = "http://172.21.240.1:8055/coupons"
+    static final String BEARER_TOKEN = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwic3R1ZGVudE51bWJlciI6IjExMSIsInJvbGUiOiJST0xFX1VTRVIiLCJpYXQiOjE3NzUzMDA5NTQsImV4cCI6MTc3NTMyNjE1NH0.AA0lijqM_eEpIUK5SZYgbF1Lf_2mgd-7z3DZEKN8w2c"
     // ==========================================
 
     static GTest test
-    static HTTPClient.HTTPConnection connection
+    static HTTPRequest request
 
     @BeforeProcess
     static void beforeProcess() {
+        request = new HTTPRequest()
+        request.headers = [
+            new NVPair("Authorization", BEARER_TOKEN),
+            new NVPair("Content-Type", "application/json")
+        ] as NVPair[]
         test = new GTest(1, "GET /coupons")
-        connection = new HTTPClient.HTTPConnection(BASE_URL)
-        grinder.logger.info("테스트 초기화 완료 - Target: ${BASE_URL}")
+        test.record(request)
+        grinder.logger.info("테스트 초기화 완료 - Target: ${TARGET_URL}")
     }
 
     @BeforeThread
     void beforeThread() {
-        test.record(this, "request")
         grinder.statistics.delayReports = true
     }
 
-    @Before
-    void before() {
-        grinder.logger.info("vUser ${grinder.threadNumber} 시작")
-    }
-
     @Test
-    void request() {
-        NVPair[] headers = [
-            new NVPair("Authorization", BEARER_TOKEN),
-            new NVPair("Content-Type", "application/json")
-        ]
-
-        HTTPResponse response = connection.Get("/coupons", null, headers)
-
+    void doRequest() {
+        def response = request.GET(TARGET_URL)
         int statusCode = response.statusCode
 
-        // 200 (성공) 또는 429 (Rate Limit 차단) 만 허용
-        // Rate Limit 없을 때는 200/기타만 나옴
         if (statusCode == 200) {
-            grinder.logger.info("vUser ${grinder.threadNumber} → 200 OK (쿠폰 발급 처리)")
+            grinder.logger.info("vUser ${grinder.threadNumber} → 200 OK")
         } else if (statusCode == 429) {
             grinder.logger.info("vUser ${grinder.threadNumber} → 429 Rate Limit 차단")
         } else {
-            grinder.logger.warn("vUser ${grinder.threadNumber} → ${statusCode} (예상치 못한 응답)")
+            grinder.logger.warn("vUser ${grinder.threadNumber} → ${statusCode}")
         }
-
-        assertTrue("응답 코드는 200 또는 429여야 합니다", statusCode == 200 || statusCode == 429)
     }
 }

--- a/src/main/java/com/example/appcenter_project/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/appcenter_project/domain/coupon/controller/CouponController.java
@@ -1,15 +1,15 @@
 package com.example.appcenter_project.domain.coupon.controller;
 
+import com.example.appcenter_project.domain.coupon.dto.request.RequestSetCouponStockDto;
 import com.example.appcenter_project.domain.coupon.dto.response.ResponseCouponDto;
 import com.example.appcenter_project.global.ratelimit.annotation.RateLimit;
 import com.example.appcenter_project.global.security.CustomUserDetails;
 import com.example.appcenter_project.domain.coupon.service.CouponService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.concurrent.TimeUnit;
 
@@ -24,5 +24,11 @@ public class CouponController {
     @GetMapping
     public ResponseEntity<ResponseCouponDto> findCoupon(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(couponService.findCoupon(userDetails.getId()));
+    }
+
+    @PostMapping("/admin/stock")
+    public ResponseEntity<Void> setStock(@Valid @RequestBody RequestSetCouponStockDto request) {
+        couponService.setStock(request.count());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/appcenter_project/domain/coupon/dto/request/RequestSetCouponStockDto.java
+++ b/src/main/java/com/example/appcenter_project/domain/coupon/dto/request/RequestSetCouponStockDto.java
@@ -1,0 +1,9 @@
+package com.example.appcenter_project.domain.coupon.dto.request;
+
+import jakarta.validation.constraints.Min;
+
+public record RequestSetCouponStockDto(
+        @Min(value = 0, message = "쿠폰 수량은 0 이상이어야 합니다.")
+        int count
+) {
+}

--- a/src/main/java/com/example/appcenter_project/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/appcenter_project/domain/coupon/service/CouponService.java
@@ -33,6 +33,7 @@ import java.time.format.DateTimeFormatter;
 public class CouponService {
 
     private static final String REDIS_KEY = "coupon_date_time";
+    private static final String REDIS_STOCK_KEY = "coupon_stock";
 
     private final CouponRepository couponRepository;
     private final NotificationRepository notificationRepository;
@@ -57,6 +58,11 @@ public class CouponService {
         if (isAlreadyHaveCoupon(userId)) {
             log.info("사용자 {}는 이미 쿠폰을 발급받았습니다.", userId);
             return ResponseCouponDto.of(true, true);
+        }
+
+        if (isStockDepletedByCache()) {
+            log.info("쿠폰 소진 (Redis 캐시 hit) - DB 조회 차단 - userId: {}", userId);
+            return ResponseCouponDto.of(false, false);
         }
 
         if (isNotExistsCoupon()) {
@@ -111,6 +117,7 @@ public class CouponService {
             createUserNotification(user, notification);
 
             couponRepository.delete(coupon);
+            decrementStockCache();
 
             log.info("쿠폰 발급 성공 - userId: {}, couponId: {}", userId, coupon.getId());
             return ResponseCouponDto.of(true, false);
@@ -124,7 +131,31 @@ public class CouponService {
         }
     }
 
+    public void setStock(int count) {
+        redisTemplate.opsForValue().set(REDIS_STOCK_KEY, String.valueOf(count));
+        log.info("쿠폰 잔여 수 Redis 초기화 - count: {}", count);
+    }
+
     // ========== Private Methods ========== //
+
+    private boolean isStockDepletedByCache() {
+        try {
+            String stockStr = redisTemplate.opsForValue().get(REDIS_STOCK_KEY);
+            if (stockStr == null) return false;
+            return Long.parseLong(stockStr) <= 0;
+        } catch (Exception e) {
+            log.warn("Redis 잔여 수 확인 실패, DB 조회로 fallback: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private void decrementStockCache() {
+        try {
+            redisTemplate.opsForValue().decrement(REDIS_STOCK_KEY);
+        } catch (Exception e) {
+            log.warn("Redis 쿠폰 잔여 수 DECR 실패: {}", e.getMessage());
+        }
+    }
 
     private String getCouponOpenTime() {
         try {

--- a/src/main/java/com/example/appcenter_project/domain/groupOrder/repository/GroupOrderCommentRepository.java
+++ b/src/main/java/com/example/appcenter_project/domain/groupOrder/repository/GroupOrderCommentRepository.java
@@ -2,6 +2,8 @@ package com.example.appcenter_project.domain.groupOrder.repository;
 
 import com.example.appcenter_project.domain.groupOrder.entity.GroupOrderComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +12,7 @@ public interface GroupOrderCommentRepository extends JpaRepository<GroupOrderCom
     List<GroupOrderComment> findByGroupOrder_Id(Long groupOrderId);
     List<GroupOrderComment> findByGroupOrderIdAndParentGroupOrderCommentIsNull(Long groupOrderId);
     Optional<GroupOrderComment> findByIdAndUserId(Long id, Long userId);
+
+    @Query("SELECT c FROM GroupOrderComment c WHERE c.groupOrder.id IN :groupOrderIds")
+    List<GroupOrderComment> findByGroupOrderIds(@Param("groupOrderIds") List<Long> groupOrderIds);
 }

--- a/src/main/java/com/example/appcenter_project/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/appcenter_project/global/config/SecurityConfig.java
@@ -152,6 +152,7 @@ public class SecurityConfig {
                         .requestMatchers("/fcm/token/**").permitAll()
 
                         /** 쿠폰 **/
+                        .requestMatchers(POST, "/coupons/admin/stock").hasRole("ADMIN")
                         .requestMatchers("/coupons/**").authenticated()
 
                         /** 설문조사 **/

--- a/src/test/java/com/example/appcenter_project/domain/coupon/service/CouponStockCacheTest.java
+++ b/src/test/java/com/example/appcenter_project/domain/coupon/service/CouponStockCacheTest.java
@@ -1,0 +1,120 @@
+package com.example.appcenter_project.domain.coupon.service;
+
+import com.example.appcenter_project.domain.coupon.dto.response.ResponseCouponDto;
+import com.example.appcenter_project.domain.coupon.entity.Coupon;
+import com.example.appcenter_project.domain.coupon.repository.CouponRepository;
+import com.example.appcenter_project.domain.notification.repository.NotificationRepository;
+import com.example.appcenter_project.domain.notification.repository.UserNotificationRepository;
+import com.example.appcenter_project.domain.user.entity.User;
+import com.example.appcenter_project.domain.user.enums.NotificationType;
+import com.example.appcenter_project.domain.user.enums.Role;
+import com.example.appcenter_project.domain.user.repository.UserRepository;
+import com.example.appcenter_project.global.cache.CouponLocalCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CouponStockCacheTest {
+
+    @InjectMocks
+    private CouponService couponService;
+
+    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private ValueOperations<String, String> valueOperations;
+    @Mock private UserRepository userRepository;
+    @Mock private CouponRepository couponRepository;
+    @Mock private UserNotificationRepository userNotificationRepository;
+    @Mock private NotificationRepository notificationRepository;
+    @Mock private CouponLocalCache couponLocalCache;
+
+    @BeforeEach
+    void setUp() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("Redis 잔여 수가 0이면 DB 조회 없이 즉시 반환한다")
+    void stock_depleted_in_cache_skips_db() {
+        User user = mock(User.class);
+        given(user.getRole()).willReturn(Role.ROLE_USER);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userNotificationRepository.existsByUserIdAndNotificationType(1L, NotificationType.COUPON))
+                .willReturn(false);
+        given(valueOperations.get("coupon_stock")).willReturn("0");
+
+        ResponseCouponDto result = couponService.findCoupon(1L);
+
+        assertThat(result.isSuccess()).isFalse();
+        verify(couponRepository, never()).count();
+    }
+
+    @Test
+    @DisplayName("Redis 잔여 수가 음수이면 DB 조회 없이 즉시 반환한다")
+    void negative_stock_cache_skips_db() {
+        User user = mock(User.class);
+        given(user.getRole()).willReturn(Role.ROLE_USER);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userNotificationRepository.existsByUserIdAndNotificationType(1L, NotificationType.COUPON))
+                .willReturn(false);
+        given(valueOperations.get("coupon_stock")).willReturn("-1");
+
+        ResponseCouponDto result = couponService.findCoupon(1L);
+
+        assertThat(result.isSuccess()).isFalse();
+        verify(couponRepository, never()).count();
+    }
+
+    @Test
+    @DisplayName("Redis 캐시 미설정(null)이면 DB 조회로 폴백한다")
+    void null_stock_cache_falls_back_to_db() {
+        User user = mock(User.class);
+        given(user.getRole()).willReturn(Role.ROLE_USER);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userNotificationRepository.existsByUserIdAndNotificationType(1L, NotificationType.COUPON))
+                .willReturn(false);
+        given(valueOperations.get("coupon_stock")).willReturn(null);
+        given(couponRepository.count()).willReturn(0L);
+
+        couponService.findCoupon(1L);
+
+        verify(couponRepository).count();
+    }
+
+    @Test
+    @DisplayName("setStock 호출 시 Redis에 지정한 수량이 저장된다")
+    void set_stock_writes_to_redis() {
+        couponService.setStock(100);
+
+        verify(valueOperations).set("coupon_stock", "100");
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 성공 시 Redis 잔여 수가 감소한다")
+    void successful_issuance_decrements_stock() {
+        User user = mock(User.class);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userNotificationRepository.existsByUserIdAndNotificationType(1L, NotificationType.COUPON))
+                .willReturn(false);
+
+        Coupon coupon = new Coupon();
+        given(couponRepository.findByIdWithLock(1L)).willReturn(Optional.of(coupon));
+
+        couponService.issuanceCoupon(1L, 1L);
+
+        verify(valueOperations).decrement("coupon_stock");
+    }
+}


### PR DESCRIPTION
## 개요
쿠폰 선착순 이벤트 시 매크로 반복 요청 및 쿠폰 소진 후에도 DB COUNT 쿼리가 계속 실행되는 문제를 사전에 식별하여
Redis 기반 2계층 방어 아키텍처를 선제 구축함

## 변경 사항
- [AOP] @RateLimit 커스텀 어노테이션 + RateLimitAspect 구현 (Redis INCR/EXPIRE, 5초당 1회 제한) (c933c4b)
- [Service] CouponService Redis 재고 캐시 적용 - 소진 시 DB 조회 차단, 발급 성공 시 DECR (c933c4b)
- [API] POST /coupons/admin/stock 재고 초기화 엔드포인트 추가 (c933c4b)
- [설정] SecurityConfig ADMIN 전용 재고 설정 경로 추가 (c933c4b)
- [테스트] CouponStockCacheTest Mockito 단위 테스트 5개 (c933c4b)
- [docs] nGrinder 부하 테스트 스크립트 멀티스레드 호환성 수정 (6a1ebfc)

## 테스트
- [ ] 로컬 빌드 확인 (`./gradlew build`)
- [ ] GET /coupons 5초 내 2회 요청 시 429 반환 확인
- [ ] POST /coupons/admin/stock 으로 재고 0 설정 후 DB 조회 차단 확인
- [ ] nGrinder 99 vUser 부하 테스트 (TPS +83%, 응답시간 -49% 기준)

closes #584
closes #585