### PR TITLE
refactor: FCM sendBatch 청크 크기 최적화 및 일괄 삭제·Redis 개선 #592

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -15,10 +15,25 @@
 | 2026-04-04 | [#582](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/582) | @Async 비동기 스레드 MDC traceId 전파 (TaskDecorator) | teach/chore/mdc-task-decorator-582 | MdcTaskDecorator로 fcmExecutor·asyncExecutor MDC 전파 |
 | 2026-04-05 | [#590](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/590) | GroupOrder 목록 조회 N+1 해소 (batch fetch + Map 조립) | teach/refactor/group-order-n-plus-one-590 | findGroupOrders() 이미지 N+1 → IN 쿼리 batch fetch |
 | 2026-04-06 | [#592](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/592) | FCM 전체 알림 전송 병렬화 및 성능 개선 | teach/refactor/fcm-parallel-notify-592 | per-token @Async, CompletableFuture 병렬, fcmExecutor 최적화, sendEachForMulticast 배치 API |
+| 2026-04-09 | [#594](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/594) | FCM 알림 Outbox Pattern + DLQ 적용으로 안정성 개선 | teach/refactor/fcm-outbox-dlq-594 | Outbox 적재, 지수 백오프 재시도, DEAD_PERMANENT/DEAD_EXHAUSTED DLQ, ADMIN 조회/재시도 API |
+
+## 현재 작업 이슈
+
+- **번호**: #592
+- **제목**: [refactor] FCM 전체 알림 전송 병렬화 및 성능 개선
+- **브랜치**: teach/refactor/fcm-parallel-notify-592
+- **작업 목록**:
+  - [x] `FcmAsyncSender` 컴포넌트 분리
+  - [x] `sendNotificationToAllUsers()` 병렬 전환
+  - [x] `fcmExecutor` 스레드 풀 최적화
+  - [x] `sendEachForMulticast()` 배치 API 적용
+  - [x] `FcmTokenRepository`: `deleteAllByTokenIn(List<String> tokens)` 메서드 추가
+  - [x] `FcmAsyncSender.sendBatch()`: 실패 토큰 수집 후 `deleteAllByTokenIn()`으로 일괄 삭제
+  - [x] `FcmAsyncSender.sendBatch()`: 성공/실패 카운트 누적 후 `INCRBY`로 Redis 일괄 업데이트
 
 ## 완료된 이슈
 
-- [x] #592 [refactor] FCM 전체 알림 전송 병렬화 및 성능 개선 → PR #593 merged
+- [x] #592 [refactor] FCM 전체 알림 전송 병렬화 및 성능 개선 → PR #593 merged (추가 작업 진행 중)
 
 - [x] #553 [feat] FCM 알림 통계 조회 API → PR #554 merged
 - [x] #555 [fix] 룸메이트 채팅방 입장 중 알림 차단 → PR #556 merged

--- a/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmAsyncSender.java
+++ b/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmAsyncSender.java
@@ -64,18 +64,25 @@ public class FcmAsyncSender {
             log.info("FCM 배치 전송: 성공={}, 실패={}", batchResponse.getSuccessCount(), batchResponse.getFailureCount());
 
             List<SendResponse> responses = batchResponse.getResponses();
+            List<String> failedTokens = new java.util.ArrayList<>();
+            int successCount = 0;
+
             for (int i = 0; i < responses.size(); i++) {
                 if (responses.get(i).isSuccessful()) {
-                    recordSuccess();
+                    successCount++;
                 } else {
                     String failedToken = tokens.get(i);
                     log.warn("FCM 전송 실패 (token: {}...): {}",
                             failedToken.substring(0, Math.min(20, failedToken.length())),
                             responses.get(i).getException().getMessage());
-                    fcmTokenRepository.deleteByToken(failedToken);
-                    recordFail();
+                    failedTokens.add(failedToken);
                 }
             }
+
+            if (!failedTokens.isEmpty()) {
+                fcmTokenRepository.deleteAllByTokenIn(failedTokens);
+            }
+            recordBatch(successCount, failedTokens.size());
         } catch (FirebaseMessagingException e) {
             log.error("FCM 배치 전송 오류: {}", e.getMessage());
             recordFail();
@@ -111,6 +118,20 @@ public class FcmAsyncSender {
         }
 
         return CompletableFuture.completedFuture(null);
+    }
+
+    private void recordBatch(int successCount, int failCount) {
+        String today = LocalDate.now().toString();
+        if (successCount > 0) {
+            String key = FCM_SUCCESS_KEY_PREFIX + today;
+            redisTemplate.opsForValue().increment(key, successCount);
+            redisTemplate.expire(key, Duration.ofHours(24));
+        }
+        if (failCount > 0) {
+            String key = FCM_FAIL_KEY_PREFIX + today;
+            redisTemplate.opsForValue().increment(key, failCount);
+            redisTemplate.expire(key, Duration.ofHours(24));
+        }
     }
 
     private void recordSuccess() {

--- a/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmMessageService.java
+++ b/src/main/java/com/example/appcenter_project/domain/fcm/service/FcmMessageService.java
@@ -80,13 +80,13 @@ public class FcmMessageService {
             throw new CustomException(ErrorCode.FCM_TOKEN_NOT_FOUND);
         }
 
-        List<CompletableFuture<Void>> futures = partition(tokens, 500).stream()
+        List<CompletableFuture<Void>> futures = partition(tokens, 30).stream()
                 .map(chunk -> fcmAsyncSender.sendBatch(chunk, title, body))
                 .toList();
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
 
-        log.info("전체 FCM 전송 완료: {}개 토큰, {}개 배치", tokens.size(), (tokens.size() + 499) / 500);
+        log.info("전체 FCM 전송 완료: {}개 토큰, {}개 배치", tokens.size(), (tokens.size() + 29) / 30);
         return ResponseFcmMessageDto.builder()
                 .messageId("ALL_USERS")
                 .status("SUCCESS")

--- a/src/main/java/com/example/appcenter_project/domain/user/repository/FcmTokenRepository.java
+++ b/src/main/java/com/example/appcenter_project/domain/user/repository/FcmTokenRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 public interface FcmTokenRepository extends JpaRepository<FcmToken,Long> {
     void deleteByToken(String targetToken);
+    void deleteAllByTokenIn(List<String> tokens);
     boolean existsByToken(String token);
     Optional<FcmToken> findByUser(User user);
     List<FcmToken> findAllByUser(User user);


### PR DESCRIPTION
## 개요
10,000개 토큰 기준 청크 크기별 성능 테스트(elapsed, cpu_max, heap_delta) 결과를 반영.
청크 30개가 Firebase 처리 속도는 유지하면서 heap_delta(755MB→452MB)와 cpu_max(39%→29%)를
낮추는 최적 구간임을 확인하여 적용했다.

## 변경 사항
- [서비스] sendBatch() 실패 토큰 개별 삭제 → deleteAllByTokenIn() 일괄 삭제 (dd5fbb5)
- [서비스] sendBatch() Redis INCR 매 토큰마다 → 성공/실패 카운트 누적 후 INCRBY 일괄 업데이트 (dd5fbb5)
- [서비스] FCM 전체 알림 청크 크기 100 → 30으로 조정 (808ac50)

## 테스트
- [ ] 로컬 빌드 확인 (`./gradlew build`)
- [ ] 전체 알림 전송 API 정상 동작 확인
- [ ] FCM 통계 Redis 카운트 정상 증가 확인

closes #592