### PR TITLE
feat: 서비스 에러 발생 시 Sentry, Slack 알림 전송 #604

### DIFF
--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -18,6 +18,18 @@
 | 2026-04-09 | [#594](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/594) | FCM 알림 Outbox Pattern + DLQ 적용으로 안정성 개선 | teach/refactor/fcm-outbox-dlq-594 | Outbox 적재, 지수 백오프 재시도, DEAD_PERMANENT/DEAD_EXHAUSTED DLQ, ADMIN 조회/재시도 API |
 | 2026-04-09 | [#596](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/596) | FCM Outbox/DLQ 성능 및 안정성 개선 | teach/refactor/fcm-outbox-improvement-596 | SKIP LOCKED, 배치 전환, Bulk Update, TTL, Dedup, Graceful Shutdown, Slack 알림 등 14개 작업 |
 | 2026-04-14 | [#601](https://github.com/Teach-D/appcenter-16.5-dormitory-project/pull/601) | FCM Outbox/DLQ 성능 및 안정성 개선 PR | teach/refactor/fcm-outbox-improvement-596 | PR #601 생성 |
+| 2026-04-19 | [#604](https://github.com/Teach-D/appcenter-16.5-dormitory-project/issues/604) | 서비스 에러 발생 시 Sentry, Slack 알림 전송 | teach/feat/sentry-slack-error-alert-604 | Sentry SDK + Slack webhook 연동, GlobalExceptionHandler 통합 |
+
+## 현재 작업 이슈
+
+- **번호**: #604
+- **제목**: [feat] 서비스 에러 발생 시 Sentry, Slack 알림 전송
+- **브랜치**: teach/feat/sentry-slack-error-alert-604
+- **작업 목록**:
+  - [ ] `build.gradle`에 `sentry-spring-boot-starter-jakarta` 의존성 추가
+  - [ ] `application.yml`에 Sentry DSN 설정 추가 (`${SENTRY_DSN:}`)
+  - [ ] `SlackErrorNotifier` 서비스 생성 (unhandled exception 전용 Slack 알림)
+  - [ ] `GlobalExceptionHandler`에 `Exception.class` 핸들러 추가 → Slack 알림 + Sentry 캡처 연결
 
 ## 완료된 이슈
 

--- a/.claude/issues.md
+++ b/.claude/issues.md
@@ -26,10 +26,10 @@
 - **제목**: [feat] 서비스 에러 발생 시 Sentry, Slack 알림 전송
 - **브랜치**: teach/feat/sentry-slack-error-alert-604
 - **작업 목록**:
-  - [ ] `build.gradle`에 `sentry-spring-boot-starter-jakarta` 의존성 추가
-  - [ ] `application.yml`에 Sentry DSN 설정 추가 (`${SENTRY_DSN:}`)
-  - [ ] `SlackErrorNotifier` 서비스 생성 (unhandled exception 전용 Slack 알림)
-  - [ ] `GlobalExceptionHandler`에 `Exception.class` 핸들러 추가 → Slack 알림 + Sentry 캡처 연결
+  - [x] `build.gradle`에 `sentry-spring-boot-starter-jakarta` 의존성 추가
+  - [x] `application.yml`에 Sentry DSN 설정 추가 (`${SENTRY_DSN:}`)
+  - [x] `SlackErrorNotifier` 서비스 생성 (unhandled exception 전용 Slack 알림)
+  - [x] `GlobalExceptionHandler`에 `Exception.class` 핸들러 추가 → Slack 알림 + Sentry 캡처 연결
 
 ## 완료된 이슈
 

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,9 @@ dependencies {
 
 	// p6spy (SQL 실행시간 로깅)
 	implementation 'p6spy:p6spy:3.9.1'
+
+	// Sentry (Spring Boot 3 / Jakarta)
+	implementation 'io.sentry:sentry-spring-boot-starter-jakarta:7.20.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/appcenter_project/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/appcenter_project/global/exception/ErrorCode.java
@@ -165,7 +165,10 @@ public enum ErrorCode {
     RATE_LIMIT_EXCEEDED(TOO_MANY_REQUESTS, 20001, "[RateLimit] 요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."),
 
     // DISTRIBUTED LOCK
-    GROUP_ORDER_VIEW_COUNT_LOCK_FAILED(SERVICE_UNAVAILABLE, 21001, "[GroupOrder] 조회수 업데이트 락 획득에 실패했습니다. 잠시 후 재시도됩니다.");
+    GROUP_ORDER_VIEW_COUNT_LOCK_FAILED(SERVICE_UNAVAILABLE, 21001, "[GroupOrder] 조회수 업데이트 락 획득에 실패했습니다. 잠시 후 재시도됩니다."),
+
+    // SERVER
+    UNHANDLED_EXCEPTION(INTERNAL_SERVER_ERROR, 99999, "[Server] 서버 내부 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/appcenter_project/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/appcenter_project/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.example.appcenter_project.global.exception;
 
+import io.sentry.Sentry;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -11,8 +14,11 @@ import javax.naming.AuthenticationException;
 import java.util.List;
 
 @Slf4j
+@RequiredArgsConstructor
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private final SlackErrorNotifier slackErrorNotifier;
 
     @ExceptionHandler(CustomException.class)
     protected ResponseEntity<ErrorResponseEntity> handleCustomException(CustomException ex) {
@@ -41,5 +47,13 @@ public class GlobalExceptionHandler {
         log.warn("MissingServletRequestPartException 발생: {}", ex.getMessage());
 
         return ErrorResponseEntity.toResponseEntity(ErrorCode.VALIDATION_FAILED);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseEntity> handleUnexpectedException(Exception ex, HttpServletRequest request) {
+        log.error("처리되지 않은 예외 발생: {} {}", request.getMethod(), request.getRequestURI(), ex);
+        Sentry.captureException(ex);
+        slackErrorNotifier.sendErrorAlert(ex, request);
+        return ErrorResponseEntity.toResponseEntity(ErrorCode.UNHANDLED_EXCEPTION);
     }
 }

--- a/src/main/java/com/example/appcenter_project/global/exception/SlackErrorNotifier.java
+++ b/src/main/java/com/example/appcenter_project/global/exception/SlackErrorNotifier.java
@@ -1,0 +1,55 @@
+package com.example.appcenter_project.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Component
+public class SlackErrorNotifier {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    @Value("${slack.webhook-url:}")
+    private String slackWebhookUrl;
+
+    public void sendErrorAlert(Exception ex, HttpServletRequest request) {
+        if (slackWebhookUrl == null || slackWebhookUrl.isBlank()) return;
+
+        String timestamp = LocalDateTime.now().format(FORMATTER);
+        String payload = buildPayload(ex, request, timestamp);
+
+        try {
+            HttpClient.newHttpClient().send(
+                    HttpRequest.newBuilder()
+                            .uri(URI.create(slackWebhookUrl))
+                            .header("Content-Type", "application/json")
+                            .POST(HttpRequest.BodyPublishers.ofString(payload))
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString()
+            );
+        } catch (Exception e) {
+            log.error("Slack 에러 알림 전송 실패: {}", e.getMessage());
+        }
+    }
+
+    private String buildPayload(Exception ex, HttpServletRequest request, String timestamp) {
+        String method = request != null ? request.getMethod() : "UNKNOWN";
+        String uri = request != null ? request.getRequestURI() : "UNKNOWN";
+        String exceptionName = ex.getClass().getSimpleName();
+        String message = ex.getMessage() != null ? ex.getMessage().replace("\"", "'") : "null";
+
+        return String.format(
+                "{\"text\": \"[서버 에러 발생]\\n• 시각: %s\\n• 요청: %s %s\\n• 예외: %s\\n• 메시지: %s\"}",
+                timestamp, method, uri, exceptionName, message
+        );
+    }
+}


### PR DESCRIPTION
## 개요
처리되지 않은 예외(unhandled exception) 발생 시 개발팀이 즉시 인지할 수 있도록
Sentry(에러 트래킹)와 Slack(실시간 알림)으로 알림을 자동 전송하는 기능을 추가한다.
기존 GlobalExceptionHandler에 통합하여 5xx 수준의 예외만 대상으로 한다.

## 변경 사항
- [설정] build.gradle에 sentry-spring-boot-starter-jakarta 의존성 추가
- [설정] application.yml에 sentry.dsn 환경변수 설정 추가 (${SENTRY_DSN:})
- [예외] SlackErrorNotifier 컴포넌트 생성 — 요청 메서드, URI, 예외명, 메시지, 타임스탬프 포함 Slack 알림 전송 (de3eca0)
- [예외] GlobalExceptionHandler에 Exception.class 핸들러 추가 → Sentry 캡처 + Slack 알림 연결 (de3eca0)
- [예외] ErrorCode에 UNHANDLED_EXCEPTION(99999) 추가

## 테스트
- [ ] 로컬 빌드 확인 (`./gradlew build`)
- [ ] 미처리 예외 발생 시 Slack 채널에 알림 메시지 수신 확인
- [ ] Sentry DSN 설정 후 Sentry 대시보드에서 에러 이벤트 캡처 확인

closes #604