### PR TITLE
feat: 오픈채팅 실시간 채팅 WebSocket + STOMP 구현 #632

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,3 +58,38 @@
 2. **테스트** — asyncRewake 훅이 백그라운드 자동 실행 (실패 시 Claude에 알림)
 3. **antipatterns 자가 검토** — `.claude/rules/antipatterns.md`, `antipatterns-jpa.md` 확인
 4. **AI 기여도 기록** — PR 완료 시 `.claude/ai-metrics.md`에 보완비율·clarification 횟수 기록
+
+## 세션 실패 기록
+### 2026-06-08 01:53 UTC (세션: 1b6c14b9)
+
+- `Bash(gh auth status 2>&1)` → `Exit code 127`
+- `Bash(git -C "C:\Users\wkadh\OneDrive\바탕 화면\coding\project\appcenter-16.5-dormitory-pr)` → `<tool_use_error>Cancelled: parallel tool call Bash(gh auth status 2>&1) errored</tool_use_error>`
+- `mcp__github__create_issue(Teach-D)` → `MCP error -32603: Failed to create issue: Bad credentials`
+
+### 2026-06-08 01:53 UTC (세션: 94d7daeb)
+
+- `Bash(gh auth status 2>&1)` → `Exit code 127`
+- `Bash(git status --porcelain 2>&1)` → `<tool_use_error>Cancelled: parallel tool call Bash(gh auth status 2>&1) errored</tool_use_error>`
+- `Glob(docs/*)` → `<tool_use_error>Cancelled: parallel tool call Bash(gh auth status) errored</tool_use_error>`
+- `mcp__github__create_issue(Teach-D)` → `MCP error -32603: Failed to create issue: Bad credentials`
+- `Bash(powershell.exe -Command "Get-Command gh -ErrorAction SilentlyContinue | Select-O)` → `Exit code 1`
+
+### 2026-06-08 01:52 UTC (세션: f654db82)
+
+- `Bash(git push)` → `Exit code 128`
+- `Bash($env:GITHUB_TOKEN)` → `Exit code 127`
+- `Bash(powershell -Command "
+\$stream = [System.IO.MemoryStream]::new([System.Text.Enco)` → `Exit code 2`
+
+### 2026-06-07 05:01 UTC (세션: 1b6c14b9)
+
+- `Bash(gh auth status 2>&1)` → `Exit code 127`
+- `Bash(git -C "C:\Users\wkadh\OneDrive\바탕 화면\coding\project\appcenter-16.5-dormitory-pr)` → `<tool_use_error>Cancelled: parallel tool call Bash(gh auth status 2>&1) errored</tool_use_error>`
+- `mcp__github__create_issue(Teach-D)` → `MCP error -32603: Failed to create issue: Bad credentials`
+
+### 2026-06-07 05:00 UTC (세션: 1b6c14b9)
+
+- `Bash(gh auth status 2>&1)` → `Exit code 127`
+- `Bash(git -C "C:\Users\wkadh\OneDrive\바탕 화면\coding\project\appcenter-16.5-dormitory-pr)` → `<tool_use_error>Cancelled: parallel tool call Bash(gh auth status 2>&1) errored</tool_use_error>`
+- `mcp__github__create_issue(Teach-D)` → `MCP error -32603: Failed to create issue: Bad credentials`
+

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1,0 +1,739 @@
+# API 명세서
+
+> 기반 요구사항: `docs/requirements.md`
+> 기반 도메인 모델: `docs/domain-model.md`
+
+---
+
+## 1. 공통 정보
+
+### Base URL
+`/open-chat-rooms`
+
+### 인증 방식
+- 헤더: `Authorization: Bearer {accessToken}`
+- 미인증 시: `401 UNAUTHORIZED`
+
+### 공통 응답 형식
+
+**성공:**
+```json
+{
+  "success": true,
+  "data": {},
+  "message": null
+}
+```
+
+**실패:**
+```json
+{
+  "success": false,
+  "data": null,
+  "message": "에러 메시지",
+  "code": "ERROR_CODE"
+}
+```
+
+### 공통 에러 코드
+
+| 코드 | HTTP Status | 설명 |
+|------|-------------|------|
+| UNAUTHORIZED | 401 | 인증 토큰 없음 또는 만료 |
+| FORBIDDEN | 403 | 권한 없음 (공개 범위 불일치, 비방장 삭제 시도 등) |
+| NOT_FOUND | 404 | 채팅방 없음 |
+| VALIDATION_ERROR | 400 | 요청값 검증 실패 |
+| OPEN_CHAT_ROOM_FULL | 400 | 최대 인원 초과 |
+| INTERNAL_ERROR | 500 | 서버 내부 오류 |
+
+### 페이지네이션
+
+**Query Parameters:**
+
+| 이름 | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| page | number | 0 | 페이지 번호 (0-based) |
+| size | number | 20 | 페이지 크기 (max: 100) |
+
+**Response 공통 필드:**
+```json
+{
+  "content": [],
+  "totalElements": 0,
+  "totalPages": 0,
+  "currentPage": 0,
+  "hasNext": false
+}
+```
+
+---
+
+## 2. API 목록
+
+---
+
+### 2-1. 채팅방 생성
+
+**`POST /open-chat-rooms`**
+
+| 항목 | 내용 |
+|------|------|
+| 설명 | 새 오픈 채팅방을 생성하고 생성자를 방장으로 등록한다 |
+| 인증 | 필요 |
+| 권한 | USER |
+| 멱등성 | 비멱등 |
+
+**Request Body:**
+```json
+{
+  "name": "string | 방 이름 | 필수",
+  "description": "string | 방 설명 | 선택",
+  "scope": "DORMITORY | ALL | 공개 범위 | 필수",
+  "maxParticipants": "number | 최대 인원 | 필수"
+}
+```
+
+**Validation Rules:**
+- `name`: 1~30자, 공백만으로 구성 불가, null 불가
+- `description`: 최대 100자, null 허용
+- `scope`: `DORMITORY` 또는 `ALL` 중 하나, null 불가
+- `maxParticipants`: 2 이상 100 이하, null 불가
+
+**Response (성공 — 201 CREATED):**
+```json
+{
+  "success": true,
+  "data": {
+    "roomId": "number | 생성된 채팅방 ID"
+  }
+}
+```
+
+**비즈니스 로직 요약:**
+1. 요청자 Role이 USER인지 검증 (BR-01)
+2. `scope = DORMITORY`이면 요청자의 `dormType`을 `creatorDormitory`로 저장, `scope = ALL`이면 `creatorDormitory = NULL`
+3. `OpenChatRoom` 생성 + `hostUserId = 요청자 ID` 설정
+4. 요청자를 첫 번째 `OpenChatParticipant`로 등록 (`joinedAt = now`)
+5. 생성된 `roomId` 반환
+
+**에러 케이스:**
+
+| 상황 | HTTP | code | message |
+|------|------|------|---------|
+| name이 없거나 30자 초과 | 400 | VALIDATION_ERROR | 방 이름은 1~30자여야 합니다 |
+| scope가 유효하지 않은 값 | 400 | VALIDATION_ERROR | 유효하지 않은 공개 범위입니다 |
+| maxParticipants가 2 미만 또는 100 초과 | 400 | VALIDATION_ERROR | 최대 인원은 2~100명이어야 합니다 |
+
+**사이드 이펙트 / 도메인 이벤트:**
+- `RoomCreated`: 방 생성 완료 시 발행 (Phase 2 — FCM 연동 시 사용)
+
+---
+
+### 2-2. 채팅방 목록 조회 (3탭)
+
+**`GET /open-chat-rooms`**
+
+| 항목 | 내용 |
+|------|------|
+| 설명 | 탭 파라미터에 따라 내 방 / 내 기숙사 / 전체 목록을 조회한다 |
+| 인증 | 필요 |
+| 권한 | USER |
+| 멱등성 | 멱등 |
+
+**Query Parameters:**
+
+| 이름 | 타입 | 필수 | 기본값 | 설명 |
+|------|------|------|--------|------|
+| tab | string | Y | - | `MY` / `DORMITORY` / `ALL` |
+| page | number | N | 0 | 페이지 번호 |
+| size | number | N | 20 | 페이지 크기 |
+
+**Response (성공 — 200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "content": [
+      {
+        "roomId": "number",
+        "name": "string | 방 이름",
+        "description": "string | null",
+        "scope": "DORMITORY | ALL",
+        "currentParticipants": "number | 현재 참여 인원",
+        "maxParticipants": "number | 최대 인원",
+        "isJoined": "boolean | 요청자가 이미 참여 중인지 여부",
+        "lastMessageAt": "string | ISO 8601 | null (메시지 없는 경우)",
+        "lastMessagePreview": "string | 최근 메시지 미리보기 (최대 30자) | null (Phase 1에서 항상 null)"
+      }
+    ],
+    "totalElements": "number",
+    "totalPages": "number",
+    "currentPage": "number",
+    "hasNext": "boolean"
+  }
+}
+```
+
+**비즈니스 로직 요약:**
+
+- `tab=MY`: 요청자가 `OpenChatParticipant`로 등록된 방만 조회
+- `tab=DORMITORY`:
+  1. 요청자 `dormType`이 `NONE`이면 빈 목록 반환 (BR-02)
+  2. `scope = DORMITORY` AND `creatorDormitory = 요청자 dormType`인 방 조회
+- `tab=ALL`: `scope = ALL`인 방 전체 조회
+- 모든 탭에서 `isJoined` 필드: 요청자가 해당 방의 참여자인지 여부
+- `lastMessagePreview`: Phase 1에서 항상 `null` 반환 (Phase 2에서 `OpenChatMessage` 연동)
+
+**에러 케이스:**
+
+| 상황 | HTTP | code | message |
+|------|------|------|---------|
+| tab이 누락되거나 유효하지 않은 값 | 400 | VALIDATION_ERROR | tab은 MY, DORMITORY, ALL 중 하나여야 합니다 |
+
+**엣지 케이스:**
+- [ ] `tab=DORMITORY`, 요청자 `dormType=NONE` → 빈 목록(`content: []`) 반환, 에러 아님
+- [ ] `tab=MY`이고 참여한 방이 없으면 빈 목록 반환
+
+---
+
+### 2-3. 채팅방 입장
+
+**`POST /open-chat-rooms/{roomId}/participants/me`**
+
+| 항목 | 내용 |
+|------|------|
+| 설명 | 지정한 채팅방에 입장한다. 이미 참여 중이면 멱등 처리한다 |
+| 인증 | 필요 |
+| 권한 | USER |
+| 멱등성 | 멱등 (이미 참여 중인 경우) |
+
+**Path Parameters:**
+
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| roomId | Long | 입장할 채팅방 ID |
+
+**Request Body:** 없음
+
+**Response (성공 — 200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "roomId": "number",
+    "name": "string",
+    "description": "string | null",
+    "scope": "DORMITORY | ALL",
+    "currentParticipants": "number",
+    "maxParticipants": "number",
+    "isOfficial": "boolean",
+    "createdAt": "string | ISO 8601"
+  }
+}
+```
+
+**비즈니스 로직 요약:**
+1. 채팅방 존재 여부 확인 — 없으면 404
+2. 이미 참여 중(`OpenChatParticipant` 존재)이면 방 정보 그대로 반환 (멱등, BR-05)
+3. `scope = DORMITORY`이면 요청자 `dormType == creatorDormitory` 검증 (BR-03) — 불일치 시 403
+4. `OpenChatRoom`에 비관적 락 획득 (ADR-03)
+5. `currentParticipants >= maxParticipants`이면 400 반환 (BR-04)
+6. `OpenChatParticipant` 신규 등록 (`joinedAt = now`, `notificationEnabled = true` 기본값)
+7. 방 상세 정보 반환
+
+**에러 케이스:**
+
+| 상황 | HTTP | code | message |
+|------|------|------|---------|
+| 존재하지 않는 roomId | 404 | NOT_FOUND | 채팅방을 찾을 수 없습니다 |
+| scope=DORMITORY + dormType 불일치 | 403 | FORBIDDEN | 해당 기숙사 전용 채팅방입니다 |
+| 최대 인원 초과 | 400 | OPEN_CHAT_ROOM_FULL | 최대 인원에 도달한 채팅방입니다 |
+
+**동시성 & 멱등성:**
+- 비관적 락 (`findByIdWithLock`) 으로 동시 입장 시 인원 초과 완전 차단
+- 이미 참여 중인 경우 추가 DB 쓰기 없이 정상 응답
+
+**사이드 이펙트 / 도메인 이벤트:**
+- `ParticipantJoined`: 신규 입장 완료 시 발행 (Phase 2 — 방장에게 FCM 알림)
+
+**엣지 케이스:**
+- [ ] 이미 참여 중인 방에 재입장 → 200 OK + 방 정보 반환 (멱등)
+- [ ] `scope=DORMITORY` + 요청자 `dormType=NONE` → 403 FORBIDDEN
+
+---
+
+### 2-4. 채팅방 나가기
+
+**`DELETE /open-chat-rooms/{roomId}/participants/me`**
+
+| 항목 | 내용 |
+|------|------|
+| 설명 | 채팅방에서 나간다. 방장이 나가면 방장 이전 또는 방 삭제가 수행된다 |
+| 인증 | 필요 |
+| 권한 | USER |
+| 멱등성 | 비멱등 |
+
+**Path Parameters:**
+
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| roomId | Long | 나갈 채팅방 ID |
+
+**Request Body:** 없음
+
+**Response (성공 — 200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "roomDeleted": "boolean | 방이 삭제되었으면 true"
+  }
+}
+```
+
+**비즈니스 로직 요약:**
+1. 채팅방 존재 여부 확인 — 없으면 404
+2. 요청자가 해당 방의 참여자인지 확인 — 아니면 404
+3. `OpenChatParticipant` 삭제 (요청자 행 제거)
+4. 요청자가 방장(`room.hostUserId == 요청자 ID`)이면 방장 이전 로직 수행 (BR-06):
+   - 남은 참여자 중 `joinedAt ASC` 기준 가장 오래된 참여자에게 `hostUserId` 이전
+   - 남은 참여자가 0명이면:
+     - `is_official = FALSE` → 방 삭제, `roomDeleted = true` 반환
+     - `is_official = TRUE` → 삭제 없이 `roomDeleted = false` 반환 (BR-07)
+5. 방장이 아니면 참여자 제거만 수행
+
+**에러 케이스:**
+
+| 상황 | HTTP | code | message |
+|------|------|------|---------|
+| 존재하지 않는 roomId | 404 | NOT_FOUND | 채팅방을 찾을 수 없습니다 |
+| 참여 중이지 않은 방 나가기 시도 | 404 | NOT_FOUND | 참여하지 않은 채팅방입니다 |
+
+**사이드 이펙트 / 도메인 이벤트:**
+- `HostTransferred`: 방장 이전 완료 시 발행 (Phase 2 — 신규 방장에게 FCM 알림)
+- `RoomDeleted`: 방 삭제 시 발행 (Phase 2 — 연관 메시지 정리)
+
+**엣지 케이스:**
+- [ ] 마지막 참여자(방장)가 나가기 + `is_official=FALSE` → 방 삭제, `roomDeleted=true`
+- [ ] 마지막 참여자(방장)가 나가기 + `is_official=TRUE` → 방장 없는 공식 방 유지, `roomDeleted=false`
+- [ ] 방장이 아닌 참여자 나가기 → 참여자 제거만 수행, `roomDeleted=false`
+
+---
+
+### 2-5. 채팅방 삭제
+
+**`DELETE /open-chat-rooms/{roomId}`**
+
+| 항목 | 내용 |
+|------|------|
+| 설명 | 채팅방을 강제 삭제한다. 방장 또는 ADMIN만 가능. is_official 방은 ADMIN만 삭제 가능 |
+| 인증 | 필요 |
+| 권한 | USER (방장) / ADMIN |
+| 멱등성 | 비멱등 |
+
+**Path Parameters:**
+
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| roomId | Long | 삭제할 채팅방 ID |
+
+**Request Body:** 없음
+
+**Response (성공 — 204 NO CONTENT):**
+```json
+(body 없음)
+```
+
+**비즈니스 로직 요약:**
+1. 채팅방 존재 여부 확인 — 없으면 404
+2. 요청자가 ADMIN이면 삭제 진행 (is_official 방 포함)
+3. 요청자가 USER이면:
+   - `room.hostUserId == 요청자 ID` 검증 (BR-08) — 불일치 시 403
+   - `is_official = TRUE`이면 403 (USER는 공식 방 삭제 불가)
+4. 방에 속한 `OpenChatParticipant` 전체 삭제 후 `OpenChatRoom` 삭제
+
+**에러 케이스:**
+
+| 상황 | HTTP | code | message |
+|------|------|------|---------|
+| 존재하지 않는 roomId | 404 | NOT_FOUND | 채팅방을 찾을 수 없습니다 |
+| 방장이 아닌 USER의 삭제 시도 | 403 | FORBIDDEN | 채팅방 삭제 권한이 없습니다 |
+| USER가 is_official 방 삭제 시도 | 403 | FORBIDDEN | 공식 채팅방은 삭제할 수 없습니다 |
+
+**사이드 이펙트 / 도메인 이벤트:**
+- `RoomDeleted`: 삭제 완료 시 발행 (Phase 2 — 참여자 FCM 알림, 메시지 정리)
+
+---
+
+## 3. 도메인 이벤트 & 사이드 이펙트 요약
+
+| API | 발행 이벤트 | 구독 주체 | 처리 내용 |
+|-----|------------|-----------|-----------|
+| 채팅방 생성 | `RoomCreated` | (Phase 2) FCM | 생성 알림 |
+| 채팅방 입장 | `ParticipantJoined` | (Phase 2) FCM | 방장에게 입장 알림 |
+| 채팅방 나가기 | `HostTransferred` | (Phase 2) FCM | 신규 방장에게 알림 |
+| 채팅방 나가기 | `RoomDeleted` | (Phase 2) 메시지 정리 | 연관 메시지 삭제 |
+| 채팅방 삭제 | `RoomDeleted` | (Phase 2) FCM, 메시지 정리 | 참여자 알림 + 메시지 삭제 |
+
+Phase 1에서 모든 이벤트는 발행하지 않음. 인터페이스 정의만 TBD.
+
+---
+
+## 4. API 간 의존 관계
+
+- `채팅방 입장(2-3)` 호출 전 `채팅방 생성(2-1)` 또는 Flyway 초기 데이터로 방이 존재해야 함
+- `채팅방 나가기(2-4)`는 `채팅방 입장(2-3)` 이후에만 유의미 (비참여자 호출 시 404)
+- `채팅방 삭제(2-5)`는 `채팅방 나가기(2-4)`와 별개 — 삭제는 강제 제거, 나가기는 자발적 탈퇴
+
+---
+
+## 5. 보안 체크리스트
+
+- [x] 모든 쓰기 API에 인증(JWT) 적용
+- [x] `scope=DORMITORY` 방 입장 시 dormType 소유권 검증 (BR-03)
+- [x] 방 삭제 시 방장 소유권 검증 (BR-08)
+- [x] `is_official` 방 USER 삭제 차단
+- [ ] 요청 body 크기 제한 (name, description 길이 제한으로 간접 제어)
+- [ ] Rate Limit: 방 생성 API (단기간 대량 방 생성 방지) — Phase 2 검토
+
+---
+
+## 6. 최종 검토
+
+- [x] ambiguous endpoint 없음 (탭 구분 명확, 나가기/삭제 분리)
+- [x] 숨겨진 동시성 위험 식별 완료 (입장 비관적 락)
+- [x] 누락된 인가 검사 없음
+- [x] Phase 1에서 `lastMessagePreview` null 반환으로 최종 일관성 처리 명시
+- [x] 멱등 입장(BR-05) 명시 완료
+
+---
+
+## 7. TBD (Phase 1)
+
+- [x] 방 목록 정렬 기준: `lastMessageAt DESC` (Phase 2에서 확정)
+- [ ] 방 검색 API (이름 키워드): Phase 1 포함 여부
+- [ ] `notification_enabled` ON/OFF 변경 API: Phase 1 포함 여부
+  - 포함 시: `PATCH /open-chat-rooms/{roomId}/participants/me/notification`
+- [ ] `is_official` 방 hostUserId NULL 처리: 첫 입장자 자동 방장 지정 vs NULL 허용 (ADR 결정 필요)
+
+---
+
+---
+
+# Phase 2 — 실시간 채팅 API (WebSocket + STOMP)
+
+> 기반 요구사항: `docs/requirements.md` § Phase 2
+> 기반 도메인 모델: `docs/domain-model.md` § Phase 2
+
+---
+
+## 8. WebSocket 연결 정보
+
+### 연결 엔드포인트
+
+| 항목 | 값 |
+|------|-----|
+| WebSocket URL | `ws://{host}/ws-stomp` |
+| SockJS URL (대체) | `http://{host}/ws-stomp-sockjs` |
+| 프로토콜 | STOMP 1.2 |
+| 인증 방식 | STOMP CONNECT 헤더 `Authorization: Bearer {accessToken}` |
+
+### STOMP 프레임 구조
+
+**CONNECT:**
+```
+CONNECT
+Authorization: Bearer {accessToken}
+accept-version:1.2
+heart-beat:10000,10000
+
+^@
+```
+
+**SUBSCRIBE (채팅방 구독):**
+```
+SUBSCRIBE
+id:sub-0
+destination:/sub/openchat/{roomId}
+
+^@
+```
+
+**SEND (메시지 발행):**
+```
+SEND
+destination:/pub/openchat/socketchat
+content-type:application/json
+
+{"roomId":1,"content":"안녕하세요"}
+^@
+```
+
+### 인증 실패 시 동작
+- STOMP CONNECT 단계에서 JWT 검증 실패 → WebSocket 연결 거부 (기존 `WebSocketAuthInterceptor` 동작)
+- 세션에 `userId`가 없는 상태에서 메시지 발행 → 서버에서 처리 중단 (클라이언트는 응답 없음)
+
+---
+
+## 9. Phase 2 API 목록
+
+---
+
+### 9-1. 메시지 발행 (WebSocket STOMP)
+
+**`SEND /pub/openchat/socketchat`** (`@MessageMapping`)
+
+| 항목 | 내용 |
+|------|------|
+| 설명 | 오픈채팅방에 텍스트 메시지를 발행한다. DB에 저장 후 해당 방 구독자 전체에 브로드캐스트 |
+| 인증 | 필요 (STOMP 세션 내 JWT) |
+| 권한 | USER (해당 방의 참여자) |
+| 멱등성 | 비멱등 |
+
+**STOMP SEND Payload:**
+```json
+{
+  "roomId": "number | 채팅방 ID | 필수",
+  "content": "string | 메시지 내용 | 필수"
+}
+```
+
+**Validation Rules:**
+- `roomId`: null 불가
+- `content`: 1자 이상, null·공백만으로 구성 불가
+
+**브로드캐스트 목적지:** `/sub/openchat/{roomId}`
+
+**브로드캐스트 페이로드 (ResponseOpenChatMessageDto):**
+```json
+{
+  "messageId": "number | 메시지 ID",
+  "roomId": "number | 채팅방 ID",
+  "senderId": "number | 발신자 유저 ID (SYSTEM=0)",
+  "senderNickname": "string | 발신자 닉네임",
+  "content": "string | 메시지 내용",
+  "type": "TEXT | SYSTEM",
+  "unreadCount": "number | 현재 읽지 않은 참여자 수",
+  "createdAt": "string | ISO 8601"
+}
+```
+
+**비즈니스 로직 요약:**
+1. STOMP 세션에서 `userId` 추출 (BR-P2-01)
+2. `OpenChatParticipant` 존재 여부로 발행자 참여자 검증 (BR-P2-02, INV-MSG-01) — 비참여자면 처리 중단
+3. `OpenChatMessage(type=TEXT)` DB 저장
+4. `OpenChatRoom.lastMessage` (최대 500자 truncate), `lastMessageAt` 갱신 (BR-P2-04, INV-MSG-03)
+5. 발신자의 `OpenChatParticipant.lastReadMessageId` = 저장된 메시지 ID로 갱신 (BR-P2-06)
+6. `unreadCount` = 방 총 참여자 수 − `lastReadMessageId ≥ messageId`인 참여자 수 계산 (ADR-04)
+7. `/sub/openchat/{roomId}`로 브로드캐스트 (BR-P2-03)
+
+**에러 케이스:**
+
+| 상황 | 처리 방식 |
+|------|-----------|
+| 세션에 userId 없음 (미인증) | 처리 중단, 클라이언트 응답 없음 |
+| 참여자가 아닌 사용자 발행 | 처리 중단, 클라이언트 응답 없음 |
+| 존재하지 않는 roomId | 처리 중단, 클라이언트 응답 없음 |
+
+**사이드 이펙트:**
+- `MessageSent`: 브로드캐스트 완료 후 (Phase 3 FCM 연동 시 오프라인 참여자 알림)
+
+**엣지 케이스:**
+- [ ] 동시에 여러 메시지 발행 시 ID 순서 보장 → DB auto-increment로 보장
+- [ ] 방 삭제 직후 발행 시도 → roomId 존재 검증 실패, 처리 중단
+
+---
+
+### 9-2. WebSocket 구독 이벤트 (서버 자동 처리)
+
+**`SUBSCRIBE /sub/openchat/{roomId}`** (클라이언트 구독 선언, 서버 자동 처리)
+
+| 항목 | 내용 |
+|------|------|
+| 설명 | 채팅방 채널을 구독한다. 서버는 구독 이벤트를 감지하여 lastReadMessageId를 자동 갱신 |
+| 인증 | 필요 (STOMP 세션) |
+
+**서버 자동 처리 (SessionSubscribeEvent):**
+1. 구독 destination에서 roomId 파싱
+2. 세션에서 userId 추출
+3. 해당 참여자의 `lastReadMessageId`를 방의 최신 메시지 ID로 갱신 (BR-P2-05)
+   - 메시지가 없으면 갱신 생략
+
+**엣지 케이스:**
+- [ ] 방에 아직 메시지가 없으면 갱신 생략 (lastReadMessageId = NULL 유지)
+- [ ] prefix `/sub/openchat/` 외 경로는 `OpenChatWebSocketEventListener`에서 무시
+
+---
+
+### 9-3. 채팅 내역 조회
+
+**`GET /open-chat-rooms/{roomId}/messages`**
+
+| 항목 | 내용 |
+|------|------|
+| 설명 | 커서 기반으로 채팅 내역을 조회한다. 조회 후 해당 참여자의 읽음 상태가 갱신된다 |
+| 인증 | 필요 |
+| 권한 | USER (해당 방의 참여자) |
+| 멱등성 | 비멱등 (읽음 상태 갱신 발생) |
+
+**Path Parameters:**
+
+| 이름 | 타입 | 설명 |
+|------|------|------|
+| roomId | Long | 조회할 채팅방 ID |
+
+**Query Parameters:**
+
+| 이름 | 타입 | 필수 | 기본값 | 설명 |
+|------|------|------|--------|------|
+| lastMessageId | Long | N | null | 커서 ID. 미전달 시 최신 30건 반환 |
+| size | number | N | 30 | 페이지 크기 (max: 50) |
+
+**Response (성공 — 200 OK):**
+```json
+{
+  "success": true,
+  "data": {
+    "messages": [
+      {
+        "messageId": "number",
+        "roomId": "number",
+        "senderId": "number | SYSTEM=0",
+        "senderNickname": "string | SYSTEM 메시지는 null",
+        "content": "string",
+        "type": "TEXT | SYSTEM",
+        "unreadCount": "number | 읽지 않은 참여자 수",
+        "createdAt": "string | ISO 8601"
+      }
+    ],
+    "hasNext": "boolean | 이전 메시지 더 있는지 여부",
+    "nextCursor": "number | 다음 조회 시 lastMessageId 값 | null (hasNext=false)"
+  }
+}
+```
+
+**비즈니스 로직 요약:**
+1. 요청자가 해당 방의 `OpenChatParticipant`인지 검증 (BR-P2-11) — 비참여자면 403
+2. `lastMessageId` 미전달: 방의 최신 메시지 30건 조회 (ID DESC limit 30 → 오름차순 정렬 후 반환)
+3. `lastMessageId` 전달: `id < lastMessageId`인 메시지 중 최신 `size`건 조회 (BR-P2-09)
+4. 각 메시지의 `unreadCount` = 방 참여자 수 − `lastReadMessageId ≥ message.id`인 참여자 수 (ADR-04)
+5. 조회자의 `OpenChatParticipant.lastReadMessageId` = 응답 메시지 중 최대 ID로 갱신 (BR-P2-09)
+6. `hasNext`: 조회된 건수 == `size`이면 true (이전 메시지 존재 가능성)
+
+**에러 케이스:**
+
+| 상황 | HTTP | code | message |
+|------|------|------|---------|
+| 존재하지 않는 roomId | 404 | NOT_FOUND | 채팅방을 찾을 수 없습니다 |
+| 참여하지 않은 방 조회 시도 | 403 | FORBIDDEN | 채팅 내역 조회 권한이 없습니다 |
+
+**동시성 & 멱등성:**
+- `lastReadMessageId` 갱신은 단일 참여자 행 UPDATE — 동시성 이슈 없음
+
+**엣지 케이스:**
+- [ ] 방에 메시지가 없으면 `messages: []`, `hasNext: false` 반환
+- [ ] `lastMessageId`가 실제 존재하지 않는 값이면 해당 ID 미만의 최신 `size`건 반환
+
+---
+
+### 9-4. 채팅방 목록 조회 — MY 탭 응답 변경 (Phase 2)
+
+**`GET /open-chat-rooms?tab=MY`** (기존 2-2 확장)
+
+Phase 2에서 MY 탭 응답에 `lastMessage`, `lastMessageAt`, `unreadCount` 필드가 추가됩니다.
+
+**Response 변경 사항 (MY 탭 한정):**
+```json
+{
+  "content": [
+    {
+      "roomId": "number",
+      "name": "string",
+      "description": "string | null",
+      "scope": "DORMITORY | ALL",
+      "currentParticipants": "number",
+      "maxParticipants": "number",
+      "isJoined": "boolean",
+      "lastMessage": "string | 최근 메시지 내용 (최대 500자) | null (메시지 없는 경우)",
+      "lastMessageAt": "string | ISO 8601 | null",
+      "unreadCount": "number | 읽지 않은 메시지 수 (내 lastReadMessageId 기준)"
+    }
+  ]
+}
+```
+
+**정렬 기준 변경:**
+- Phase 1: 정렬 기준 미확정
+- Phase 2: `lastMessageAt DESC` (메시지 없는 방은 `createdAt DESC`로 하단 정렬) (BR-P2-10)
+
+**비즈니스 로직 추가:**
+- `unreadCount` = 방의 메시지 중 `id > 내 lastReadMessageId`인 건수 (BR-P2-10, ADR-04)
+- `lastReadMessageId = NULL`이면 해당 방의 전체 메시지 수를 `unreadCount`로 반환
+
+---
+
+### 9-5. 시스템 메시지 (자동 생성, API 없음)
+
+입장/퇴장 시 서버 내부에서 자동으로 SYSTEM 메시지를 생성하고 브로드캐스트합니다.
+
+**트리거 조건:**
+
+| 이벤트 | 트리거 시점 | 메시지 내용 | senderId |
+|--------|-----------|-----------|----------|
+| 입장 | `joinRoom()` 완료 후 | `{닉네임}님이 입장했습니다` | 0 (시스템) |
+| 퇴장 | `leaveRoom()` 완료 후 | `{닉네임}님이 퇴장했습니다` | 0 (시스템) |
+
+**브로드캐스트 페이로드 (동일 형식, type=SYSTEM):**
+```json
+{
+  "messageId": "number",
+  "roomId": "number",
+  "senderId": 0,
+  "senderNickname": null,
+  "content": "홍길동님이 입장했습니다",
+  "type": "SYSTEM",
+  "unreadCount": "number",
+  "createdAt": "string | ISO 8601"
+}
+```
+
+**트랜잭션 전략:** 입장/퇴장 트랜잭션과 별개 트랜잭션으로 저장 (ADR-06)
+- 입장/퇴장 성공 후 시스템 메시지 저장 실패 시 → 입장/퇴장 자체는 롤백되지 않음
+
+---
+
+## 10. Phase 2 도메인 이벤트 & 사이드 이펙트 요약
+
+| API / 트리거 | 발행 이벤트 | 구독 주체 | 처리 내용 |
+|-------------|-----------|-----------|-----------|
+| 메시지 발행 (9-1) | `MessageSent` | `SimpMessagingTemplate` | `/sub/openchat/{roomId}` 브로드캐스트 |
+| 채팅방 입장 (2-3) | `ParticipantJoined` | `OpenChatMessageService` | SYSTEM 메시지 저장 + 브로드캐스트 |
+| 채팅방 나가기 (2-4) | `ParticipantLeft` | `OpenChatMessageService` | SYSTEM 메시지 저장 + 브로드캐스트 |
+| 구독 이벤트 (9-2) | (내부) | `OpenChatWebSocketEventListener` | `lastReadMessageId` 갱신 |
+
+---
+
+## 11. Phase 2 API 간 의존 관계
+
+- 메시지 발행(9-1) 전 WebSocket CONNECT 및 채팅방 구독(9-2) 선행 필요
+- 채팅 내역 조회(9-3)는 채팅방 입장(2-3) 완료 후 가능 (참여자 검증)
+- MY 탭 목록(9-4)의 `unreadCount`는 채팅 내역 조회(9-3) 또는 구독(9-2) 시 자동 갱신
+
+---
+
+## 12. Phase 2 보안 체크리스트
+
+- [x] WebSocket CONNECT 시 JWT 검증 (`WebSocketAuthInterceptor` 재사용)
+- [x] 메시지 발행 시 발행자 = 해당 방 참여자 검증 (INV-MSG-01)
+- [x] 채팅 내역 조회 시 참여자 검증 (BR-P2-11)
+- [x] SYSTEM 메시지 senderId=0 고정 (클라이언트 위조 불가 — 서버 내부 생성) (ADR-05)
+- [ ] Rate Limit: 단기간 대량 메시지 발행 방지 — Phase 3 검토
+
+---
+
+## 13. Phase 2 TBD
+
+- [ ] STOMP ERROR 프레임 스펙: 클라이언트 발행 오류 시 어떤 형식으로 에러를 전달할지
+- [ ] `unreadCount` 계산에서 SYSTEM 메시지 포함 여부 (현재: 포함)
+- [ ] FCM 오프라인 알림 발송 조건 및 형식 (Phase 3)
+- [ ] 이미지 메시지 지원 시 `type=IMAGE` + 이미지 URL 필드 추가 (Phase 3)

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -1,0 +1,366 @@
+# 도메인 모델
+
+> 기반 요구사항: `docs/requirements.md`
+
+---
+
+## 1. 유비쿼터스 언어 (Ubiquitous Language)
+
+| 용어 | 정의 |
+|------|------|
+| 오픈채팅방 (OpenChatRoom) | 기숙사생이 자유롭게 개설하는 채팅 공간. 공개 범위에 따라 전체 또는 특정 기숙사에게만 노출 |
+| 참여자 (Participant) | 채팅방에 입장한 유저. 방당 최대 인원 제한 있음 |
+| 방장 (Host) | 채팅방의 현재 관리자. 생성자 또는 방장 이전으로 지정된 참여자 |
+| 공개 범위 (Scope) | DORMITORY(특정 기숙사) 또는 ALL(전체 공개) |
+| 공식 방 (Official Room) | 서비스가 직접 생성한 방. created_by=NULL + is_official=TRUE 조합으로 식별. 삭제 보호 적용 |
+| 방장 이전 | 현재 방장이 나갈 때 joined_at 기준 가장 오래된 참여자에게 방장 권한 자동 이전 |
+| 기숙사 탭 (Dormitory Tab) | 요청자의 DormType과 creator_dormitory가 일치하는 방만 노출하는 목록 탭 |
+| 멱등 입장 | 이미 참여 중인 방에 재입장 요청 시 에러 없이 roomId 정상 반환 |
+| 메시지 (Message) | 참여자가 채팅방에 발행한 텍스트. TEXT(일반), SYSTEM(시스템 알림) 구분 |
+| 마지막 읽은 메시지 (lastReadMessageId) | 각 참여자가 마지막으로 읽은 메시지 ID. 읽지 않은 메시지 수 계산의 기준 |
+| 읽지 않은 사람 수 (unreadCount) | 특정 메시지를 아직 읽지 않은 참여자 수. 총 참여자 수 − lastReadMessageId ≥ 해당 메시지 ID인 참여자 수 |
+| 시스템 메시지 | 입장/퇴장 이벤트 시 자동 생성되는 메시지. type=SYSTEM |
+
+---
+
+## 2. 바운디드 컨텍스트
+
+```
+[ OpenChat Context ]          [ User Context ]
+  OpenChatRoom                  User (ID 참조만)
+  OpenChatParticipant           DormType (enum 공유)
+  OpenChatMessage (Phase 2)
+```
+
+User 컨텍스트는 ID와 DormType만 참조. User 엔티티 직접 소유 금지.
+
+---
+
+## 3. 애그리거트
+
+### Aggregate: OpenChatRoom
+
+#### 책임
+채팅방 참여 인원의 일관성(최대 인원 초과 방지, 방장 단일성)과 공개 범위 접근 제어를 보호한다.
+
+#### 애그리거트 루트
+`OpenChatRoom`
+
+#### 엔티티 & 값 객체
+
+| 구분 | 이름 | 핵심 속성 | 설명 |
+|------|------|-----------|------|
+| Entity (Root) | OpenChatRoom | id, name, description, scope, maxParticipants, creatorDormitory, hostUserId, lastMessageAt, **lastMessage**, isOfficial, createdBy, createdAt | 채팅방 메타정보 및 현재 방장. lastMessage는 Phase 2에서 추가 |
+| Entity | OpenChatParticipant | id, roomId, userId, notificationEnabled, joinedAt, **lastReadMessageId** | 루트가 소유하는 참여자 컬렉션 멤버. lastReadMessageId는 Phase 2에서 추가 |
+| VO | RoomScope | DORMITORY \| ALL | 공개 범위. 변경 불가 값 객체 |
+
+#### 비즈니스 불변식 (Invariants)
+
+- **INV-01**: 참여자 수는 `maxParticipants`를 초과할 수 없다
+  - 위반 시: 400 OPEN_CHAT_ROOM_FULL
+- **INV-02**: `hostUserId`는 현재 참여자 목록 중 정확히 1명을 가리켜야 한다
+  - 위반 시: 방장 이전 또는 방 삭제로 일관성 복구
+- **INV-03**: `scope = DORMITORY`인 방의 입장자는 `user.dormType == creatorDormitory`이어야 한다
+  - 위반 시: 403 FORBIDDEN
+- **INV-04**: `is_official = TRUE`인 방은 참여자 수가 0이 되어도 삭제되지 않는다
+  - 위반 시: 삭제 로직 진입 차단
+
+#### 라이프사이클 & 상태 머신
+
+OpenChatRoom에 별도 status 필드 없음. 상태는 참여자 수와 isOfficial로 암묵적으로 표현.
+
+```
+[생성] --입장--> [활성: 참여자 1명 이상]
+[활성] --나가기(방장, 참여자 1명)--> [삭제] (is_official=FALSE만)
+[활성] --나가기(방장, 참여자 N명)--> [방장 이전] --> [활성]
+[활성] --ADMIN 삭제--> [삭제]
+```
+
+#### 트랜잭션 경계
+
+- **방 생성**: OpenChatRoom + OpenChatParticipant(첫 번째 = 방장) 동시 생성 → 단일 트랜잭션
+- **방 입장**: OpenChatRoom 락 획득 → 인원 체크 → OpenChatParticipant 삽입 → 단일 트랜잭션
+- **방 나가기**: OpenChatParticipant 삭제 → 방장 이전(필요 시 OpenChatRoom.hostUserId 업데이트) → 참여자 0명이면 OpenChatRoom 삭제 → 단일 트랜잭션
+
+#### 동시성 고려사항
+
+- **비관적 락 (SELECT FOR UPDATE)**: 방 입장 시 `OpenChatRoom` 행에 락 획득 후 인원 수 체크
+  - 이유: 마지막 자리를 두고 동시 입장 시 `maxParticipants` 초과 방지
+  - 적용 대상: `OpenChatRoomRepository.findByIdWithLock(roomId)`
+- **방장 이전**: 단일 트랜잭션 내에서 처리되므로 추가 락 불필요
+
+#### 도메인 이벤트
+
+- `RoomCreated`: 방 생성 완료 시 발행 (Phase 2 - FCM 알림 연동 시 사용)
+- `ParticipantJoined`: 새 참여자 입장 시 발행 (Phase 2)
+- `HostTransferred`: 방장 이전 완료 시 발행 (Phase 2)
+- `RoomDeleted`: 방 삭제 시 발행 (Phase 2 - 연관 메시지 정리)
+
+---
+
+### Aggregate: OpenChatMessage (Phase 2 구현)
+
+#### 책임
+채팅 메시지의 원자적 저장을 보장하고, 발행 후 방의 lastMessage/lastMessageAt 갱신 및 발신자의 lastReadMessageId 동기화를 주도한다.
+
+#### 애그리거트 루트
+`OpenChatMessage`
+
+#### 엔티티 & 값 객체
+
+| 구분 | 이름 | 핵심 속성 | 설명 |
+|------|------|-----------|------|
+| Entity (Root) | OpenChatMessage | id, roomId, senderId, content, type, createdAt | 개별 메시지. Room과 ID 참조로 연결 |
+| VO | MessageType | TEXT \| IMAGE \| **SYSTEM** | 메시지 종류. SYSTEM은 입장/퇴장 자동 생성 |
+
+#### 비즈니스 불변식 (Invariants)
+
+- **INV-MSG-01**: 메시지 발행자(senderId)는 해당 방의 `OpenChatParticipant`로 등록된 참여자여야 한다
+  - 위반 시: 메시지 처리 중단 (STOMP ERROR 또는 무시)
+- **INV-MSG-02**: SYSTEM 메시지의 senderId는 0 (시스템 발행)으로 고정
+- **INV-MSG-03**: `lastMessage`는 메시지 내용 최대 500자 truncate 후 저장
+
+#### 트랜잭션 경계
+
+메시지 저장(`OpenChatMessage` INSERT) + 방 정보 갱신(`OpenChatRoom.lastMessage`, `lastMessageAt` UPDATE) + 발신자 읽음 갱신(`OpenChatParticipant.lastReadMessageId` UPDATE)을 **단일 트랜잭션**으로 처리.
+
+이유: lastMessage/lastMessageAt 갱신 실패 시 목록 미리보기가 stale 상태로 남는 것을 방지.
+
+#### 동시성 고려사항
+
+메시지 저장은 append-only로 경쟁 조건 없음. `lastReadMessageId` 갱신은 단순 UPDATE(단일 참여자 행)이므로 락 불필요.
+
+#### 도메인 이벤트
+
+- `MessageSent`: 메시지 저장 완료 후 발행 → STOMP 브로드캐스트 트리거
+
+---
+
+## 4. 애그리거트 관계도
+
+```
+User (외부 컨텍스트)
+  │  (userId로만 참조)
+  │
+  ├──[createdBy]──> OpenChatRoom (Aggregate Root)
+  │                   │
+  │                   └──[1:N]──> OpenChatParticipant
+  │                                 (roomId + userId 복합 UQ)
+  │
+  └──[senderId]──> OpenChatMessage (별도 Aggregate)
+                      (roomId로 OpenChatRoom 참조)
+```
+
+---
+
+## 5. 도메인 이벤트
+
+| 이벤트명 | 발행 주체 | 발행 시점 | 구독 주체 | 처리 내용 |
+|----------|-----------|-----------|-----------|-----------|
+| RoomCreated | OpenChatRoom | 방 생성 완료 | (Phase 3) FCM | 참여자 알림 |
+| ParticipantJoined | OpenChatRoom | 입장 완료 | **OpenChatMessageService** | SYSTEM 메시지 저장 + 브로드캐스트 |
+| ParticipantLeft | OpenChatRoom | 퇴장 완료 | **OpenChatMessageService** | SYSTEM 메시지 저장 + 브로드캐스트 |
+| HostTransferred | OpenChatRoom | 방장 이전 완료 | (Phase 3) FCM | 신규 방장 알림 |
+| RoomDeleted | OpenChatRoom | 방 삭제 | OpenChatMessage | 연관 메시지 cascade 삭제 |
+| MessageSent | OpenChatMessage | 메시지 저장 완료 | SimpMessagingTemplate | `/sub/openchat/{roomId}` 브로드캐스트 |
+
+**Phase 2 이벤트 발행 전략**: 도메인 이벤트 대신 `OpenChatRoomService`에서 `OpenChatMessageService`를 직접 호출하는 방식으로 구현 (단순성 우선, Phase 3에서 이벤트 기반으로 전환 가능).
+
+---
+
+## 6. 도메인 서비스
+
+### OpenChatRoomHostTransferService
+
+- **책임**: 방장 나가기 시 단일 트랜잭션 내 방장 이전 또는 방 삭제 결정
+- **관여 애그리거트**: OpenChatRoom, OpenChatParticipant
+- **로직 요약**:
+  1. 나가는 유저가 방장인지 확인 (`room.hostUserId == leavingUserId`)
+  2. 방장이면: 남은 참여자를 `joinedAt ASC` 정렬하여 첫 번째에게 방장 이전 (`room.hostUserId` 업데이트)
+  3. 참여자가 0명이고 `is_official = FALSE`이면: 방 삭제
+  4. `is_official = TRUE`이면: 삭제 없이 방장 이전만 수행
+- **트랜잭션 전략**: 단일 트랜잭션 (OpenChatRoom + OpenChatParticipant 동시 변경)
+
+### OpenChatMessageService (Phase 2 신규)
+
+- **책임**: STOMP 메시지 발행 처리, 시스템 메시지 생성, 브로드캐스트, 읽음 상태 갱신, 커서 기반 채팅 내역 조회
+- **관여 애그리거트**: OpenChatMessage, OpenChatRoom(lastMessage 갱신), OpenChatParticipant(lastReadMessageId 갱신)
+- **로직 요약**:
+  1. **sendMessage**: 발행자 참여자 검증 → OpenChatMessage 저장 → OpenChatRoom lastMessage/lastMessageAt 갱신 → 발신자 lastReadMessageId 갱신 → `/sub/openchat/{roomId}` 브로드캐스트
+  2. **sendSystemMessage**: SYSTEM 타입 메시지 저장 + 브로드캐스트 (senderId=0)
+  3. **getMessages**: 참여자 검증 → 커서 기반 조회 → 조회자 lastReadMessageId 갱신 → 응답 반환
+  4. **updateLastRead**: `SessionSubscribeEvent` 시 lastReadMessageId를 방의 최신 메시지 ID로 갱신
+- **트랜잭션 전략**: sendMessage는 단일 트랜잭션. STOMP 브로드캐스트는 트랜잭션 커밋 후 수행
+
+---
+
+## 7. 크로스-애그리거트 상호작용
+
+| 상황 | 관여 애그리거트 | 일관성 전략 | 이유 |
+|------|----------------|-------------|------|
+| 방 입장 시 인원 초과 체크 | OpenChatRoom → OpenChatParticipant | 단일 트랜잭션 + 비관적 락 | INV-01 보장 |
+| 방장 나가기 → 방장 이전 | OpenChatRoom + OpenChatParticipant | 단일 트랜잭션 | 방장 단일성(INV-02) 보장 |
+| 메시지 전송 → lastMessage/lastMessageAt 갱신 | OpenChatMessage → OpenChatRoom | 단일 트랜잭션 (직접 호출) | 목록 미리보기 즉시 반영 |
+| 메시지 전송 → 발신자 lastReadMessageId 갱신 | OpenChatMessage → OpenChatParticipant | 단일 트랜잭션 | 발신자 미읽음 카운트 0 보장 |
+| 구독(SessionSubscribeEvent) → lastReadMessageId 갱신 | 없음(서비스 직접) → OpenChatParticipant | 별도 트랜잭션 (이벤트 리스너) | 구독 시점 읽음 상태 최신화 |
+| 채팅 내역 조회 → lastReadMessageId 갱신 | 없음(서비스 직접) → OpenChatParticipant | 단일 트랜잭션 | 조회 = 읽음 처리로 간주 |
+| 입장/퇴장 → SYSTEM 메시지 발행 | OpenChatRoom → OpenChatMessage | 별도 트랜잭션 (OpenChatRoomService → OpenChatMessageService 직접 호출) | 입장/퇴장 트랜잭션과 분리, 실패해도 입장/퇴장 롤백 불필요 |
+
+---
+
+## 8. 레포지토리 인터페이스
+
+### OpenChatRoomRepository
+
+```
+// 3탭 조회
+findMyRooms(userId): List<OpenChatRoom>
+findByCreatorDormitory(dormType): List<OpenChatRoom>
+findAllPublic(): List<OpenChatRoom>
+
+// 입장 시 비관적 락
+findByIdWithLock(roomId): Optional<OpenChatRoom>
+```
+
+### OpenChatParticipantRepository
+
+```
+// 방장 이전용 — joinedAt ASC 정렬, 나가는 유저 제외
+findOldestParticipantExcluding(roomId, excludeUserId): Optional<OpenChatParticipant>
+
+// 멱등 입장 체크
+existsByRoomIdAndUserId(roomId, userId): boolean
+
+// 현재 인원 수
+countByRoomId(roomId): int
+
+// 나가기
+findByRoomIdAndUserId(roomId, userId): Optional<OpenChatParticipant>
+```
+
+### OpenChatParticipantRepository (Phase 2 추가)
+
+```
+// 읽지 않은 사람 수 계산: 방의 참여자 중 lastReadMessageId < messageId인 수
+countUnreadParticipants(roomId, messageId): int
+
+// lastReadMessageId 갱신
+updateLastReadMessageId(roomId, userId, messageId): void
+
+// MY 탭 unreadCount 계산: 방별 id > lastReadMessageId인 메시지 수
+findMyRoomsWithUnreadCount(userId): List<OpenChatParticipantWithUnread>
+```
+
+### OpenChatMessageRepository (Phase 2 구현)
+
+```
+// 커서 기반 페이징 (lastMessageId 미전달 시 최신 30건)
+findByRoomIdWithCursor(roomId, lastMessageId, size): List<OpenChatMessage>
+
+// 방의 최신 메시지 ID (구독 시 lastReadMessageId 갱신용)
+findLatestMessageIdByRoomId(roomId): Optional<Long>
+
+// unreadCount 계산용
+countByRoomIdAndIdGreaterThan(roomId, lastReadMessageId): long
+```
+
+---
+
+## 9. 패키지 구조 제안
+
+```
+com.example.appcenter_project
+└── domain/
+    └── openChat/
+        ├── controller/
+        │   ├── OpenChatRoomController.java
+        │   └── OpenChatRoomApiSpecification.java
+        ├── dto/
+        │   ├── request/
+        │   │   ├── RequestCreateOpenChatRoomDto.java
+        │   │   └── RequestJoinOpenChatRoomDto.java  (roomId PathVariable 사용 시 불필요)
+        │   └── response/
+        │       ├── ResponseOpenChatRoomDto.java      (목록용 — isJoined 포함)
+        │       └── ResponseOpenChatRoomDetailDto.java (방 입장 후 상세)
+        ├── entity/
+        │   ├── OpenChatRoom.java
+        │   ├── OpenChatParticipant.java
+        │   └── OpenChatMessage.java
+        ├── enums/
+        │   ├── OpenChatRoomScope.java   (DORMITORY, ALL)
+        │   └── OpenChatMessageType.java (TEXT, IMAGE)
+        ├── repository/
+        │   ├── OpenChatRoomRepository.java
+        │   ├── OpenChatParticipantRepository.java
+        │   └── OpenChatMessageRepository.java
+        ├── service/
+        │   ├── OpenChatRoomService.java
+        │   ├── OpenChatRoomHostTransferService.java
+        │   └── OpenChatMessageService.java          ← Phase 2 신규
+        └── config/ (global/config/)
+            └── OpenChatWebSocketEventListener.java  ← Phase 2 신규 (global 패키지)
+```
+
+---
+
+## 10. 설계 결정 사항 (ADR)
+
+### ADR-01: OpenChatParticipant를 OpenChatRoom 애그리거트 내부에 귀속
+
+- **결정**: OpenChatParticipant는 OpenChatRoom의 자식 엔티티
+- **이유**: 인원 초과 체크(INV-01)와 방장 이전(INV-02)이 단일 트랜잭션으로 처리되어야 하며, 두 엔티티의 변경이 항상 함께 발생
+- **trade-off**: 참여자 수가 매우 많아지면 애그리거트 로딩 비용 증가. 현재 MVP 규모에서 무방하며, 이후 필요 시 별도 애그리거트로 분리 가능
+
+### ADR-02: 방장 정보를 OpenChatRoom.hostUserId 필드로 관리
+
+- **결정**: `OpenChatRoom`에 `hostUserId` 컬럼 추가
+- **이유**: 방장 확인이 매 요청마다 필요한데, Room 조회 한 번으로 방장 식별 가능. 방장 이전 시 Room + Participant 동시 업데이트가 단일 트랜잭션 내에서 처리됨
+- **trade-off**: 방장 이전 시 두 엔티티를 동시에 업데이트해야 하지만, 애그리거트 내부 작업이므로 일관성 보장
+
+### ADR-03: 방 입장 시 비관적 락 적용
+
+- **결정**: `findByIdWithLock` (SELECT FOR UPDATE)으로 OpenChatRoom 행 락 획득 후 인원 체크
+- **이유**: 마지막 자리 동시 입장 시 `maxParticipants` 초과를 완전히 차단. MVP에서 입장 요청 빈도가 높지 않아 락 경합 위험 낮음
+- **trade-off**: 동시 입장 폭증 시 DB 락 경합. 향후 트래픽 증가 시 낙관적 락 또는 Redis 분산 락으로 전환 검토
+
+### ADR-04: lastReadMessageId를 OpenChatParticipant에 보관 (Phase 2)
+
+- **결정**: 별도 읽음 추적 테이블(`open_chat_message_read`) 없이 `OpenChatParticipant.lastReadMessageId` 단일 컬럼으로 관리
+- **이유**: N명 × M메시지 규모의 읽음 테이블은 불필요한 복잡성. 오픈채팅 특성상 "커서 기준 이후 메시지 수"가 unreadCount로 충분히 근사
+- **trade-off**: 메시지를 순서대로 읽지 않은 케이스(스크롤 점프)에서 unreadCount 부정확 가능. 허용 가능한 수준으로 판단
+
+### ADR-05: SYSTEM 메시지 senderId=0 고정 (Phase 2)
+
+- **결정**: 시스템 메시지의 `senderId`를 0(존재하지 않는 유저 ID)으로 고정
+- **이유**: NULL 허용 시 스키마 변경 필요, senderId가 외부 컨텍스트 User ID 참조이므로 0을 시스템 예약으로 사용
+- **trade-off**: 클라이언트에서 senderId=0 체크로 시스템 메시지 판별 필요. `type=SYSTEM` 필드로 이중 판별 가능
+
+### ADR-06: 입장/퇴장 SYSTEM 메시지를 별도 트랜잭션으로 발행 (Phase 2)
+
+- **결정**: `joinRoom()`, `leaveRoom()` 트랜잭션 커밋 후 `OpenChatMessageService.sendSystemMessage()` 별도 호출
+- **이유**: SYSTEM 메시지 저장 실패 시 입장/퇴장 자체가 롤백되는 것은 과도한 결합. 시스템 메시지는 부가 정보
+- **trade-off**: 입장 성공 후 시스템 메시지 저장 실패 시 알림 누락. 허용 가능한 수준
+
+---
+
+## 11. 아키텍처 위험 요소
+
+- **방장 이전 실패 시 무방장 상태**: `OpenChatRoomHostTransferService`가 트랜잭션 실패 시 방장 없는 방이 생길 수 있음 → 단일 트랜잭션 보장 필수
+- **is_official 방의 방장 지정**: `created_by=NULL` 공식 방의 `hostUserId`가 NULL이면 방장 확인 로직에서 NPE 가능 → 첫 입장 유저를 방장으로 설정하거나 hostUserId NULL 허용으로 명시적 처리 필요
+- **DORMITORY scope 필터링 정확성**: `creatorDormitory` 컬럼이 NULL인 ALL 방을 기숙사 탭에 노출하지 않도록 WHERE 조건 명시 필요
+- **[Phase 2] lastReadMessageId NULL 초기값**: 신규 참여자의 lastReadMessageId가 NULL인 경우 unreadCount 계산 시 NPE 또는 전체 메시지를 unread로 처리하는 로직 필요 → NULL = 0으로 간주, COUNT(id > 0) = 전체 메시지 수
+- **[Phase 2] STOMP 세션과 HTTP 세션의 userId 불일치**: WebSocketAuthInterceptor에서 세션에 저장한 userId가 올바르게 전파되는지 확인 필요 (룸메이트 채팅의 기존 패턴 재사용으로 위험 낮음)
+- **[Phase 2] 메시지 전송 후 STOMP 브로드캐스트 타이밍**: `@Transactional` 메서드 내부에서 `messagingTemplate.convertAndSend()` 호출 시 트랜잭션 롤백 후에도 WebSocket 메시지가 이미 전송될 수 있음 → 룸메이트 채팅과 동일 패턴으로 허용
+
+---
+
+## 12. TBD
+
+- [x] 방 목록 정렬 기준: `last_message_at DESC` (Phase 2에서 확정)
+- [x] 페이지네이션 방식: 채팅 내역은 커서 기반, 방 목록은 offset 유지
+- [ ] 방 상세 조회 API 별도 필요 여부
+- [ ] `notification_enabled` ON/OFF 변경 API Phase 1 포함 여부
+- [ ] is_official 방 hostUserId NULL 처리 전략
+- [ ] [Phase 2] unreadCount 계산에서 SYSTEM 메시지 포함 여부 (현재: 포함)
+- [ ] [Phase 3] FCM 오프라인 알림 발송 전략
+- [ ] [Phase 3] 이미지 메시지 지원

--- a/docs/issue-list.md
+++ b/docs/issue-list.md
@@ -1,0 +1,9 @@
+# Issue List
+
+> 생성일: 2026-06-08
+> 총 이슈 수: 2개
+
+| 순서 | 번호 | 타입 | 제목 | 선행 이슈 | 브랜치 |
+|------|------|------|------|-----------|--------|
+| 1 | #630 | feat | 오픈채팅 Phase 1 — DB 스키마 & 채팅방 CRUD | 없음 | teach/feat/open-chat-phase1-630 |
+| 2 | #632 | feat | 오픈채팅 Phase 2 — 실시간 채팅 (WebSocket + STOMP) | #630 | teach/feat/open-chat-phase2-632 |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,259 @@
+# 요구사항 명세서
+
+> 기능: 오픈채팅 (Phase 1 — 채팅방 CRUD / Phase 2 — 실시간 채팅)
+
+---
+
+## 1. 개요
+
+- **서비스 목적**: 기숙사생이 오픈 채팅방을 생성·입장·탈퇴하고 공개 범위에 따른 3탭 목록을 조회할 수 있는 기능 (실시간 채팅은 Phase 2)
+- **핵심 사용자**: 기숙사 입주 학생 (USER)
+- **범위**
+  - In Scope: 채팅방 생성, 방 목록 3탭 조회(내 방 / 내 기숙사 / 전체), 방 입장, 방 나가기, 초기 9개 공식 방 Flyway 삽입
+  - Out of Scope: 실시간 채팅 메시지 전송·수신 (Phase 2), 채팅 신고, 채팅방 검색
+
+---
+
+## 2. 도메인 모델 후보
+
+### 엔티티 목록
+
+| 엔티티 | 핵심 속성 |
+|--------|-----------|
+| `OpenChatRoom` | id, name, description, scope(DORMITORY/ALL), maxParticipants, creatorDormitory(DormType), lastMessageAt, isOfficial, createdBy(User FK, nullable), createdAt |
+| `OpenChatParticipant` | id, room(FK), user(FK), notificationEnabled, joinedAt |
+| `OpenChatMessage` | id, room(FK), sender(FK), content, type(TEXT/IMAGE), createdAt |
+
+### 엔티티 간 관계
+
+- `OpenChatRoom` 1 ↔ N `OpenChatParticipant`
+- `OpenChatRoom` 1 ↔ N `OpenChatMessage`
+- `User` 1 ↔ N `OpenChatParticipant` (한 유저가 여러 방에 참여 가능)
+- `User` 1 ↔ N `OpenChatRoom` (방 생성자, nullable — 공식 방은 NULL)
+
+### 서비스 생성 방 식별자
+
+- `created_by = NULL` + `is_official = TRUE` 조합이 공식 방의 식별자
+- 공식 방은 방장 이전·자동 삭제 로직에서 제외, seed 유저 의존 없음
+
+---
+
+## 3. 비즈니스 규칙
+
+1. **BR-01** USER만 채팅방 생성 가능
+   - 위반 시: 403 FORBIDDEN
+
+2. **BR-02** `scope = DORMITORY`인 방은 `creator_dormitory = 요청자 DormType`인 경우에만 "내 기숙사 탭" 목록에 노출
+   - `DormType = NONE` 유저의 내 기숙사 탭: 빈 목록 반환 (오류 아님)
+
+3. **BR-03** `scope = DORMITORY`인 방에 직접 입장 시 요청자 DormType ≠ creator_dormitory → 입장 차단
+   - 위반 시: 403 FORBIDDEN (링크 우회 차단)
+
+4. **BR-04** 현재 참여 인원 ≥ max_participants인 방에 입장 시도 → 입장 불가
+   - 위반 시: 400 BAD_REQUEST (OPEN_CHAT_ROOM_FULL)
+
+5. **BR-05** 이미 참여 중인 방에 재입장 요청 → 멱등 처리 (에러 없이 roomId 정상 응답)
+   - 앱 재시작·탭 이동 등 중복 요청이 자연 발생하는 환경 고려
+
+6. **BR-06** 방장이 나가기 → `joined_at` 기준 가장 오래된 참여자에게 방장 자동 이전
+   - 참여자가 0명이 되면 방 자동 삭제 (단, `is_official = TRUE` 방은 삭제 보호)
+
+7. **BR-07** `is_official = TRUE` 방은 방장 이전·자동 삭제 로직 적용 제외
+   - `is_official` 방에서 방장이 나가도 삭제되지 않고 다음 참여자에게 방장 이전만 수행
+
+8. **BR-08** 방 삭제 권한: 방장 또는 ADMIN
+   - `is_official = TRUE` 방은 ADMIN만 삭제 가능
+   - 위반 시: 403 FORBIDDEN
+
+9. **BR-09** 방 목록 응답에 `isJoined` 필드 포함
+   - "내 기숙사 탭"과 "전체 탭"에서 이미 참여한 방 구분 표시
+
+---
+
+## 4. 사용자 & 권한
+
+| 역할 | 접근 가능 리소스 |
+|------|-----------------|
+| `USER` | 방 생성(본인), 방 목록 3탭 조회, 방 입장, 방 나가기, 방 삭제(본인이 방장인 경우) |
+| `ADMIN` | 방 삭제 전체 (is_official 포함) |
+| 비인증 | 없음 (전체 인증 필요) |
+
+---
+
+## 5. 주요 시나리오
+
+### Happy Path
+
+1. USER가 오픈 채팅방을 생성한다 (`scope=ALL`, `maxParticipants=50`)
+2. 다른 USER가 "전체 탭"에서 해당 방을 발견하고 입장한다
+3. 입장 후 "내 방 탭"에 해당 방이 추가되고 `isJoined=true`로 표시된다
+4. 방장(생성자)이 나가기를 요청하면 다음 참여자(joined_at 가장 오래된)에게 방장이 이전된다
+
+### 예외 시나리오
+
+| 시나리오 | 처리 방식 |
+|----------|-----------|
+| DORM_1 유저가 `scope=DORMITORY` + `creator_dormitory=DORM_2` 방 입장 시도 | 403 FORBIDDEN (BR-03) |
+| 최대 인원이 가득 찬 방에 입장 시도 | 400 OPEN_CHAT_ROOM_FULL (BR-04) |
+| 이미 참여 중인 방에 재입장 요청 | 멱등 처리, roomId 정상 응답 (BR-05) |
+| 유일한 참여자(방장)가 나가기 | 참여자 0명 → 방 자동 삭제 (is_official=FALSE인 경우만) |
+| is_official 방에서 방장 나가기 | 방장 이전만 수행, 방 삭제 없음 (BR-07) |
+| DormType=NONE 유저의 내 기숙사 탭 요청 | 빈 목록 반환 (BR-02) |
+
+---
+
+## 6. 비기능 요구사항
+
+- **성능**: 목록 조회 응답 200ms 이내
+- **정렬 기준**: TBD (last_message_at DESC vs 참여자 수 vs 생성 시간)
+- **페이지네이션**: TBD (offset vs cursor)
+- **데이터 보존**: `is_official = TRUE` 방은 영구 보존, 일반 방은 참여자 0명 시 자동 삭제
+- **외부 연동**: 없음 (Phase 2에서 WebSocket 연동 예정)
+
+---
+
+## 7. 미결 사항 (TBD)
+
+- [ ] 방 목록 정렬 기준: `last_message_at DESC` vs 참여자 수 DESC vs 생성 시간 DESC
+- [ ] 페이지네이션 방식: offset 기반 vs cursor 기반
+- [ ] 방 상세 조회 API 별도 필요 여부 (입장 응답에 상세 정보 포함 가능)
+- [ ] `notification_enabled` ON/OFF 변경 API Phase 1 포함 여부
+- [ ] `open_chat_message` 테이블 Phase 1에서 실제 사용 여부 (테이블 생성만, API 없음)
+- [ ] 방 검색 기능 (이름 키워드) Phase 1 포함 여부
+
+---
+
+## 8. 초기 데이터 (Flyway 삽입 대상)
+
+| 방 이름 | scope | creator_dormitory | is_official | created_by |
+|---------|-------|-------------------|-------------|------------|
+| 1긱 오픈채팅 | DORMITORY | DORM_1 | TRUE | NULL |
+| 2긱 오픈채팅 | DORMITORY | DORM_2 | TRUE | NULL |
+| 3긱 오픈채팅 | DORMITORY | DORM_3 | TRUE | NULL |
+| 1긱 공동구매방 | DORMITORY | DORM_1 | TRUE | NULL |
+| 2긱 공동구매방 | DORMITORY | DORM_2 | TRUE | NULL |
+| 3긱 공동구매방 | DORMITORY | DORM_3 | TRUE | NULL |
+| 기숙사 생활 질문방 | ALL | NULL | TRUE | NULL |
+| 기숙사 입사 준비방 | ALL | NULL | TRUE | NULL |
+| 여름방학 심심한 사람들 | ALL | NULL | TRUE | NULL |
+
+---
+
+---
+
+# Phase 2 — 실시간 채팅 (WebSocket + STOMP)
+
+## 1. 개요
+
+- **서비스 목적**: 오픈채팅 방 참여자들이 실시간으로 메시지를 송수신하고, 채팅 내역을 커서 기반으로 조회하며, 내 채팅방 목록에서 최신 메시지 미리보기를 확인
+- **핵심 사용자**: 기숙사 입주 학생 (USER)
+- **범위**
+  - In Scope: STOMP `@MessageMapping` 메시지 발행·브로드캐스트, 메시지 DB 저장, 시스템 메시지(입장/퇴장), 채팅 내역 커서 기반 페이징 조회, 메시지별 읽지 않은 사람 수, 내 채팅방 목록 최신 메시지 정렬·미리보기
+  - Out of Scope: FCM 오프라인 알림(Phase 3), 이미지 메시지(Phase 3), 메시지 삭제·수정, 공지 고정
+
+---
+
+## 2. 도메인 모델 변경
+
+### 엔티티 변경 사항
+
+| 엔티티 | 추가 컬럼 | 비고 |
+|--------|-----------|------|
+| `OpenChatRoom` | `lastMessage VARCHAR(500)` | 방 목록 미리보기용 |
+| `OpenChatParticipant` | `lastReadMessageId BIGINT` | 읽지 않은 메시지 수 산정용 |
+| `OpenChatMessageType` | `SYSTEM` 타입 추가 | 입장/퇴장 시스템 메시지 |
+
+### 읽지 않은 사람 수 산정 방식
+
+메시지 M의 **읽지 않은 사람 수** = 방의 총 참여자 수 − (lastReadMessageId ≥ M.id 인 참여자 수)
+
+### 새 컴포넌트
+
+- `OpenChatWebSocketEventListener`: 구독 이벤트 감지, `lastReadMessageId` 갱신 (룸메이트의 `RoommateWebSocketEventListener`와 동일 패턴)
+- `OpenChatMessageService`: 메시지 발행·저장·브로드캐스트 담당
+
+---
+
+## 3. 비즈니스 규칙 (Phase 2)
+
+1. **BR-P2-01** 메시지 발행 엔드포인트: STOMP `/pub/openchat/socketchat` (`@MessageMapping`만 사용)
+2. **BR-P2-02** 발행자는 해당 방의 `OpenChatParticipant`로 등록된 참여자여야 함
+   - 위반 시: 메시지 처리 중단 (STOMP ERROR 프레임 또는 무시)
+3. **BR-P2-03** 메시지 저장 후 방 구독자 전체에 브로드캐스트 (`/sub/openchat/{roomId}`)
+4. **BR-P2-04** 메시지 저장 후 `OpenChatRoom.lastMessage`(내용 최대 500자 truncate), `lastMessageAt` 즉시 갱신
+5. **BR-P2-05** 참여자가 `/sub/openchat/{roomId}` 구독 시 (`SessionSubscribeEvent`) `lastReadMessageId`를 현재 방의 최신 메시지 ID로 갱신
+6. **BR-P2-06** 메시지 발송 후 발신자의 `lastReadMessageId`도 해당 메시지 ID로 갱신
+7. **BR-P2-07** 입장 시 SYSTEM 메시지(`{닉네임}님이 입장했습니다`) 저장 + `/sub/openchat/{roomId}` 브로드캐스트
+   - Phase 1의 `joinRoom()` 서비스에서 직접 발행
+8. **BR-P2-08** 퇴장 시 SYSTEM 메시지(`{닉네임}님이 퇴장했습니다`) 저장 + 브로드캐스트
+   - Phase 1의 `leaveRoom()` 서비스에서 직접 발행
+9. **BR-P2-09** 채팅 내역 조회: 커서 기반 페이징, 기본 30건, 오래된 방향(ID 오름차순)으로 반환
+   - `lastMessageId` 미전달 시 가장 최신 30건 반환
+   - 조회 후 해당 참여자의 `lastReadMessageId` 갱신 (응답에 포함된 최신 메시지 ID로)
+10. **BR-P2-10** 내 채팅방 목록(MY 탭): `lastMessageAt` DESC 정렬, 응답에 `lastMessage`, `lastMessageAt`, `unreadCount` 포함
+    - `unreadCount` = 방의 메시지 중 id > 내 `lastReadMessageId` 인 건수
+11. **BR-P2-11** 채팅 내역 조회는 해당 방의 참여자만 가능
+    - 위반 시: 403 FORBIDDEN
+
+---
+
+## 4. 사용자 & 권한 (Phase 2)
+
+| 역할 | 접근 가능 리소스 |
+|------|-----------------|
+| `USER` (참여자) | WebSocket 메시지 발행, 채팅 내역 조회, 내 방 목록 조회 |
+| `USER` (비참여자) | 채팅 내역 조회 불가, 메시지 발행 불가 |
+| 비인증 | WebSocket 연결 거부 (WebSocketAuthInterceptor) |
+
+---
+
+## 5. 주요 시나리오 (Phase 2)
+
+### Happy Path — 메시지 발행
+
+1. USER가 STOMP CONNECT → JWT 검증 → 세션에 `userId` 저장
+2. `/sub/openchat/{roomId}` 구독 → `lastReadMessageId` 갱신
+3. `/pub/openchat/socketchat`으로 메시지 발행 (`roomId`, `content` 포함)
+4. 서버: 참여자 검증 → `OpenChatMessage` 저장 → `lastMessage`, `lastMessageAt` 갱신 → 발신자 `lastReadMessageId` 갱신
+5. `/sub/openchat/{roomId}` 전체 구독자에게 메시지 응답 브로드캐스트
+
+### Happy Path — 채팅 내역 조회
+
+1. `GET /openchat/{roomId}/messages?size=30` (첫 조회)
+2. 참여자 검증 후 최신 30건 반환
+3. 응답 후 `lastReadMessageId` 갱신
+4. 이전 메시지 조회: `GET /openchat/{roomId}/messages?lastMessageId={id}&size=30`
+
+### Happy Path — 내 채팅방 목록(MY 탭)
+
+1. `GET /openchat/rooms?tab=MY`
+2. 참여 중인 방을 `lastMessageAt` DESC 정렬
+3. 각 방의 `lastMessage`, `lastMessageAt`, `unreadCount`(내 lastReadMessageId 기준) 포함 응답
+
+### 예외 시나리오
+
+| 시나리오 | 처리 방식 |
+|----------|-----------|
+| WebSocket 미인증 발행 | 세션 userId 없음 → 처리 중단 |
+| 참여자가 아닌 사용자의 발행 | 참여자 검증 실패 → 처리 중단 |
+| 존재하지 않는 roomId로 발행 | 방 조회 실패 → 처리 중단 |
+| lastMessageId가 실제 존재하지 않는 경우 | 해당 ID 미만 최신 30건 반환 |
+| 방 삭제 후 구독자가 메시지 수신 | 브로드캐스트 수신 없음 (정상) |
+
+---
+
+## 6. 비기능 요구사항 (Phase 2)
+
+- **성능**: 채팅 내역 조회 200ms 이내, 커서 기반 인덱스(`room_id, id DESC`) 활용
+- **WebSocket**: 기존 `/ws-stomp` 엔드포인트 재사용 (설정 변경 없음)
+- **세션 관리**: `OpenChatWebSocketEventListener` 신규 생성, prefix `/sub/openchat/` 로 분리 관리
+- **데이터 보존**: 메시지 hard delete 없음, 방 삭제 시 메시지 cascade 삭제
+
+---
+
+## 7. 미결 사항 (Phase 2 TBD)
+
+- [ ] 오프라인 참여자 FCM 알림 발송 (Phase 3)
+- [ ] 이미지 메시지 지원 (Phase 3)
+- [ ] 메시지 최대 길이 제한 (현재 TEXT 타입, 필요 시 500자 논의)
+- [ ] 입장/퇴장 시스템 메시지의 `unreadCount` 포함 여부

--- a/src/main/java/com/example/appcenter_project/domain/openChat/controller/OpenChatMessageApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/controller/OpenChatMessageApiSpecification.java
@@ -1,0 +1,21 @@
+package com.example.appcenter_project.domain.openChat.controller;
+
+import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatMessageListDto;
+import com.example.appcenter_project.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "OpenChat Message", description = "오픈 채팅 메시지 API")
+public interface OpenChatMessageApiSpecification {
+
+    @Operation(summary = "채팅 메시지 목록 조회", description = "커서 기반 페이지네이션으로 채팅 메시지를 조회한다")
+    ResponseEntity<ResponseOpenChatMessageListDto> getMessages(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long roomId,
+            @RequestParam(required = false) Long lastMessageId,
+            @RequestParam(defaultValue = "30") int size);
+}

--- a/src/main/java/com/example/appcenter_project/domain/openChat/controller/OpenChatMessageController.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/controller/OpenChatMessageController.java
@@ -1,0 +1,46 @@
+package com.example.appcenter_project.domain.openChat.controller;
+
+import com.example.appcenter_project.domain.openChat.dto.request.RequestOpenChatMessageDto;
+import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatMessageListDto;
+import com.example.appcenter_project.domain.openChat.service.OpenChatMessageService;
+import com.example.appcenter_project.global.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/open-chat-rooms")
+public class OpenChatMessageController implements OpenChatMessageApiSpecification {
+
+    private final OpenChatMessageService openChatMessageService;
+
+    @MessageMapping("/openchat/socketchat")
+    public void sendChatViaWebSocket(@Valid RequestOpenChatMessageDto dto, SimpMessageHeaderAccessor headerAccessor) {
+        Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+        if (sessionAttributes == null) return;
+        String userIdStr = (String) sessionAttributes.get("userId");
+        if (userIdStr == null) return;
+        Long userId = Long.parseLong(userIdStr);
+        openChatMessageService.sendMessage(userId, dto);
+    }
+
+    @GetMapping("/{roomId}/messages")
+    public ResponseEntity<ResponseOpenChatMessageListDto> getMessages(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long roomId,
+            @RequestParam(required = false) Long lastMessageId,
+            @RequestParam(defaultValue = "30") int size) {
+        return ResponseEntity.ok(openChatMessageService.getMessages(user.getId(), roomId, lastMessageId, size));
+    }
+}

--- a/src/main/java/com/example/appcenter_project/domain/openChat/dto/request/RequestOpenChatMessageDto.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/dto/request/RequestOpenChatMessageDto.java
@@ -1,0 +1,14 @@
+package com.example.appcenter_project.domain.openChat.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RequestOpenChatMessageDto {
+    private Long roomId;
+
+    @NotBlank
+    private String content;
+}

--- a/src/main/java/com/example/appcenter_project/domain/openChat/dto/response/ResponseOpenChatMessageDto.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/dto/response/ResponseOpenChatMessageDto.java
@@ -1,0 +1,34 @@
+package com.example.appcenter_project.domain.openChat.dto.response;
+
+import com.example.appcenter_project.domain.openChat.entity.OpenChatMessage;
+import com.example.appcenter_project.domain.openChat.enums.OpenChatMessageType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ResponseOpenChatMessageDto {
+    private Long messageId;
+    private Long roomId;
+    private Long senderId;
+    private String senderNickname;
+    private String content;
+    private OpenChatMessageType type;
+    private int unreadCount;
+    private LocalDateTime createdAt;
+
+    public static ResponseOpenChatMessageDto from(OpenChatMessage message, String senderNickname, int unreadCount) {
+        return ResponseOpenChatMessageDto.builder()
+                .messageId(message.getId())
+                .roomId(message.getRoomId())
+                .senderId(message.getSenderId())
+                .senderNickname(senderNickname)
+                .content(message.getContent())
+                .type(message.getType())
+                .unreadCount(unreadCount)
+                .createdAt(message.getCreatedDate())
+                .build();
+    }
+}

--- a/src/main/java/com/example/appcenter_project/domain/openChat/dto/response/ResponseOpenChatMessageListDto.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/dto/response/ResponseOpenChatMessageListDto.java
@@ -1,0 +1,14 @@
+package com.example.appcenter_project.domain.openChat.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ResponseOpenChatMessageListDto {
+    private List<ResponseOpenChatMessageDto> messages;
+    private boolean hasNext;
+    private Long nextCursor;
+}

--- a/src/main/java/com/example/appcenter_project/domain/openChat/dto/response/ResponseOpenChatRoomDto.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/dto/response/ResponseOpenChatRoomDto.java
@@ -19,7 +19,8 @@ public class ResponseOpenChatRoomDto {
     private int maxParticipants;
     private boolean isJoined;
     private LocalDateTime lastMessageAt;
-    private String lastMessagePreview;
+    private String lastMessage;
+    private int unreadCount;
 
     public static ResponseOpenChatRoomDto from(OpenChatRoom room, int currentParticipants, boolean joined) {
         return ResponseOpenChatRoomDto.builder()
@@ -31,7 +32,23 @@ public class ResponseOpenChatRoomDto {
                 .maxParticipants(room.getMaxParticipants())
                 .isJoined(joined)
                 .lastMessageAt(room.getLastMessageAt())
-                .lastMessagePreview(null)
+                .lastMessage(room.getLastMessage())
+                .unreadCount(0)
+                .build();
+    }
+
+    public static ResponseOpenChatRoomDto from(OpenChatRoom room, int currentParticipants, boolean joined, int unreadCount) {
+        return ResponseOpenChatRoomDto.builder()
+                .roomId(room.getId())
+                .name(room.getName())
+                .description(room.getDescription())
+                .scope(room.getScope())
+                .currentParticipants(currentParticipants)
+                .maxParticipants(room.getMaxParticipants())
+                .isJoined(joined)
+                .lastMessageAt(room.getLastMessageAt())
+                .lastMessage(room.getLastMessage())
+                .unreadCount(unreadCount)
                 .build();
     }
 }

--- a/src/main/java/com/example/appcenter_project/domain/openChat/entity/OpenChatParticipant.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/entity/OpenChatParticipant.java
@@ -30,6 +30,8 @@ public class OpenChatParticipant {
     @Column(nullable = false)
     private LocalDateTime joinedAt;
 
+    private Long lastReadMessageId;
+
     public static OpenChatParticipant create(Long roomId, Long userId, LocalDateTime joinedAt) {
         OpenChatParticipant participant = new OpenChatParticipant();
         participant.roomId = roomId;
@@ -37,5 +39,9 @@ public class OpenChatParticipant {
         participant.joinedAt = joinedAt;
         participant.notificationEnabled = true;
         return participant;
+    }
+
+    public void updateLastReadMessageId(Long messageId) {
+        this.lastReadMessageId = messageId;
     }
 }

--- a/src/main/java/com/example/appcenter_project/domain/openChat/entity/OpenChatRoom.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/entity/OpenChatRoom.java
@@ -38,6 +38,9 @@ public class OpenChatRoom extends BaseTimeEntity {
 
     private LocalDateTime lastMessageAt;
 
+    @Column(length = 500)
+    private String lastMessage;
+
     @Column(nullable = false)
     private boolean isOfficial;
 
@@ -60,5 +63,10 @@ public class OpenChatRoom extends BaseTimeEntity {
 
     public void updateHost(Long userId) {
         this.hostUserId = userId;
+    }
+
+    public void updateLastMessage(String content, LocalDateTime at) {
+        this.lastMessage = content != null && content.length() > 500 ? content.substring(0, 500) : content;
+        this.lastMessageAt = at;
     }
 }

--- a/src/main/java/com/example/appcenter_project/domain/openChat/enums/OpenChatMessageType.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/enums/OpenChatMessageType.java
@@ -1,5 +1,5 @@
 package com.example.appcenter_project.domain.openChat.enums;
 
 public enum OpenChatMessageType {
-    TEXT, IMAGE
+    TEXT, IMAGE, SYSTEM
 }

--- a/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatMessageQuerydslRepository.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatMessageQuerydslRepository.java
@@ -1,0 +1,12 @@
+package com.example.appcenter_project.domain.openChat.repository;
+
+import com.example.appcenter_project.domain.openChat.entity.OpenChatMessage;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OpenChatMessageQuerydslRepository {
+    List<OpenChatMessage> findByRoomIdWithCursor(Long roomId, Long lastMessageId, int size);
+    Optional<Long> findLatestMessageIdByRoomId(Long roomId);
+    long countByRoomIdAndIdGreaterThan(Long roomId, Long lastReadMessageId);
+}

--- a/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatMessageQuerydslRepositoryImpl.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatMessageQuerydslRepositoryImpl.java
@@ -1,0 +1,73 @@
+package com.example.appcenter_project.domain.openChat.repository;
+
+import com.example.appcenter_project.domain.openChat.entity.OpenChatMessage;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.example.appcenter_project.domain.openChat.entity.QOpenChatMessage.openChatMessage;
+
+public class OpenChatMessageQuerydslRepositoryImpl implements OpenChatMessageQuerydslRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public OpenChatMessageQuerydslRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<OpenChatMessage> findByRoomIdWithCursor(Long roomId, Long lastMessageId, int size) {
+        List<OpenChatMessage> results = queryFactory
+                .selectFrom(openChatMessage)
+                .where(
+                        openChatMessage.roomId.eq(roomId),
+                        idLessThan(lastMessageId)
+                )
+                .orderBy(openChatMessage.id.desc())
+                .limit(size)
+                .fetch();
+
+        List<OpenChatMessage> reversed = new ArrayList<>(results);
+        java.util.Collections.reverse(reversed);
+        return reversed;
+    }
+
+    @Override
+    public Optional<Long> findLatestMessageIdByRoomId(Long roomId) {
+        Long result = queryFactory
+                .select(openChatMessage.id.max())
+                .from(openChatMessage)
+                .where(openChatMessage.roomId.eq(roomId))
+                .fetchOne();
+        return Optional.ofNullable(result);
+    }
+
+    @Override
+    public long countByRoomIdAndIdGreaterThan(Long roomId, Long lastReadMessageId) {
+        if (lastReadMessageId == null) {
+            Long count = queryFactory
+                    .select(openChatMessage.count())
+                    .from(openChatMessage)
+                    .where(openChatMessage.roomId.eq(roomId))
+                    .fetchOne();
+            return count != null ? count : 0L;
+        }
+        Long count = queryFactory
+                .select(openChatMessage.count())
+                .from(openChatMessage)
+                .where(
+                        openChatMessage.roomId.eq(roomId),
+                        openChatMessage.id.gt(lastReadMessageId)
+                )
+                .fetchOne();
+        return count != null ? count : 0L;
+    }
+
+    private BooleanExpression idLessThan(Long lastMessageId) {
+        return lastMessageId != null ? openChatMessage.id.lt(lastMessageId) : null;
+    }
+}

--- a/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatMessageRepository.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatMessageRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OpenChatMessageRepository extends JpaRepository<OpenChatMessage, Long> {
+public interface OpenChatMessageRepository extends JpaRepository<OpenChatMessage, Long>, OpenChatMessageQuerydslRepository {
 
     Slice<OpenChatMessage> findByRoomIdOrderByCreatedDateAsc(Long roomId, Pageable pageable);
 }

--- a/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatParticipantQuerydslRepository.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatParticipantQuerydslRepository.java
@@ -7,4 +7,6 @@ import java.util.Set;
 public interface OpenChatParticipantQuerydslRepository {
     Map<Long, Long> countByRoomIds(List<Long> roomIds);
     Set<Long> findJoinedRoomIds(Long userId, List<Long> roomIds);
+    Map<Long, Long> findLastReadMessageIdsByUserId(Long userId, List<Long> roomIds);
+    long countReadByRoomIdAndMessageId(Long roomId, Long messageId);
 }

--- a/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatParticipantQuerydslRepositoryImpl.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatParticipantQuerydslRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.example.appcenter_project.domain.openChat.repository;
 
+import com.example.appcenter_project.domain.openChat.entity.OpenChatParticipant;
 import com.example.appcenter_project.domain.openChat.entity.QOpenChatParticipant;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -53,5 +54,36 @@ public class OpenChatParticipantQuerydslRepositoryImpl implements OpenChatPartic
                 .fetch();
 
         return new HashSet<>(results);
+    }
+
+    @Override
+    public Map<Long, Long> findLastReadMessageIdsByUserId(Long userId, List<Long> roomIds) {
+        List<OpenChatParticipant> participants = queryFactory
+                .selectFrom(openChatParticipant)
+                .where(
+                        openChatParticipant.userId.eq(userId),
+                        openChatParticipant.roomId.in(roomIds)
+                )
+                .fetch();
+
+        Map<Long, Long> result = new HashMap<>();
+        for (OpenChatParticipant participant : participants) {
+            result.put(participant.getRoomId(), participant.getLastReadMessageId());
+        }
+        return result;
+    }
+
+    @Override
+    public long countReadByRoomIdAndMessageId(Long roomId, Long messageId) {
+        Long count = queryFactory
+                .select(openChatParticipant.count())
+                .from(openChatParticipant)
+                .where(
+                        openChatParticipant.roomId.eq(roomId),
+                        openChatParticipant.lastReadMessageId.isNotNull(),
+                        openChatParticipant.lastReadMessageId.goe(messageId)
+                )
+                .fetchOne();
+        return count != null ? count : 0L;
     }
 }

--- a/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatParticipantRepository.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatParticipantRepository.java
@@ -35,4 +35,9 @@ public interface OpenChatParticipantRepository extends JpaRepository<OpenChatPar
     @Transactional
     @Query("DELETE FROM OpenChatParticipant p WHERE p.roomId = :roomId")
     void deleteAllByRoomId(@Param("roomId") Long roomId);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE OpenChatParticipant p SET p.lastReadMessageId = :messageId WHERE p.roomId = :roomId AND p.userId = :userId")
+    void updateLastReadMessageId(@Param("roomId") Long roomId, @Param("userId") Long userId, @Param("messageId") Long messageId);
 }

--- a/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatRoomQuerydslRepositoryImpl.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatRoomQuerydslRepositoryImpl.java
@@ -29,6 +29,10 @@ public class OpenChatRoomQuerydslRepositoryImpl implements OpenChatRoomQuerydslR
                         openChatRoom.id.eq(openChatParticipant.roomId),
                         openChatParticipant.userId.eq(userId)
                 )
+                .orderBy(
+                        openChatRoom.lastMessageAt.desc().nullsLast(),
+                        openChatRoom.createdDate.desc()
+                )
                 .fetch();
     }
 

--- a/src/main/java/com/example/appcenter_project/domain/openChat/service/OpenChatMessageService.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/service/OpenChatMessageService.java
@@ -1,0 +1,119 @@
+package com.example.appcenter_project.domain.openChat.service;
+
+import com.example.appcenter_project.domain.openChat.dto.request.RequestOpenChatMessageDto;
+import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatMessageDto;
+import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatMessageListDto;
+import com.example.appcenter_project.domain.openChat.entity.OpenChatMessage;
+import com.example.appcenter_project.domain.openChat.entity.OpenChatParticipant;
+import com.example.appcenter_project.domain.openChat.entity.OpenChatRoom;
+import com.example.appcenter_project.domain.openChat.enums.OpenChatMessageType;
+import com.example.appcenter_project.domain.openChat.repository.OpenChatMessageRepository;
+import com.example.appcenter_project.domain.openChat.repository.OpenChatParticipantRepository;
+import com.example.appcenter_project.domain.openChat.repository.OpenChatRoomRepository;
+import com.example.appcenter_project.domain.user.entity.User;
+import com.example.appcenter_project.domain.user.repository.UserRepository;
+import com.example.appcenter_project.global.exception.CustomException;
+import com.example.appcenter_project.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OpenChatMessageService {
+
+    private final OpenChatRoomRepository openChatRoomRepository;
+    private final OpenChatParticipantRepository openChatParticipantRepository;
+    private final OpenChatMessageRepository openChatMessageRepository;
+    private final UserRepository userRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void sendMessage(Long userId, RequestOpenChatMessageDto request) {
+        OpenChatRoom room = openChatRoomRepository.findById(request.getRoomId()).orElse(null);
+        if (room == null) return;
+
+        OpenChatParticipant participant = openChatParticipantRepository
+                .findByRoomIdAndUserId(request.getRoomId(), userId).orElse(null);
+        if (participant == null) return;
+
+        User sender = userRepository.findById(userId).orElse(null);
+        if (sender == null) return;
+
+        OpenChatMessage message = OpenChatMessage.create(request.getRoomId(), userId, request.getContent(), OpenChatMessageType.TEXT);
+        openChatMessageRepository.save(message);
+
+        room.updateLastMessage(message.getContent(), message.getCreatedDate());
+
+        participant.updateLastReadMessageId(message.getId());
+
+        int unreadCount = calculateUnreadCount(request.getRoomId(), message.getId());
+
+        ResponseOpenChatMessageDto response = ResponseOpenChatMessageDto.from(message, sender.getName(), unreadCount);
+        messagingTemplate.convertAndSend("/sub/openchat/" + request.getRoomId(), response);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void sendSystemMessage(Long roomId, String content) {
+        OpenChatRoom room = openChatRoomRepository.findById(roomId).orElse(null);
+        if (room == null) return;
+
+        OpenChatMessage message = OpenChatMessage.create(roomId, 0L, content, OpenChatMessageType.SYSTEM);
+        openChatMessageRepository.save(message);
+
+        room.updateLastMessage(message.getContent(), message.getCreatedDate());
+
+        int unreadCount = calculateUnreadCount(roomId, message.getId());
+
+        ResponseOpenChatMessageDto response = ResponseOpenChatMessageDto.from(message, null, unreadCount);
+        messagingTemplate.convertAndSend("/sub/openchat/" + roomId, response);
+    }
+
+    @Transactional
+    public ResponseOpenChatMessageListDto getMessages(Long userId, Long roomId, Long lastMessageId, int size) {
+        openChatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.OPEN_CHAT_ROOM_NOT_FOUND));
+
+        openChatParticipantRepository.findByRoomIdAndUserId(roomId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.OPEN_CHAT_NOT_PARTICIPANT));
+
+        List<OpenChatMessage> messages = openChatMessageRepository.findByRoomIdWithCursor(roomId, lastMessageId, size + 1);
+
+        boolean hasNext = messages.size() > size;
+        if (hasNext) {
+            messages = messages.subList(0, size);
+        }
+
+        Long latestId = messages.isEmpty() ? null : messages.get(messages.size() - 1).getId();
+        if (latestId != null) {
+            openChatParticipantRepository.updateLastReadMessageId(roomId, userId, latestId);
+        }
+
+        List<ResponseOpenChatMessageDto> dtos = messages.stream()
+                .map(msg -> {
+                    String nickname = msg.getType() == OpenChatMessageType.SYSTEM ? null :
+                            userRepository.findById(msg.getSenderId()).map(User::getName).orElse(null);
+                    int unreadCount = calculateUnreadCount(roomId, msg.getId());
+                    return ResponseOpenChatMessageDto.from(msg, nickname, unreadCount);
+                })
+                .toList();
+
+        Long nextCursor = hasNext && !messages.isEmpty() ? messages.get(0).getId() : null;
+
+        return ResponseOpenChatMessageListDto.builder()
+                .messages(dtos)
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
+                .build();
+    }
+
+    public int calculateUnreadCount(Long roomId, Long messageId) {
+        long total = openChatParticipantRepository.countByRoomId(roomId);
+        long readCount = openChatParticipantRepository.countReadByRoomIdAndMessageId(roomId, messageId);
+        return (int) (total - readCount);
+    }
+}

--- a/src/main/java/com/example/appcenter_project/domain/openChat/service/OpenChatRoomService.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/service/OpenChatRoomService.java
@@ -8,13 +8,15 @@ import com.example.appcenter_project.domain.openChat.entity.OpenChatParticipant;
 import com.example.appcenter_project.domain.openChat.entity.OpenChatRoom;
 import com.example.appcenter_project.domain.openChat.enums.OpenChatRoomScope;
 import com.example.appcenter_project.domain.openChat.enums.OpenChatRoomTab;
+import com.example.appcenter_project.domain.openChat.repository.OpenChatMessageRepository;
 import com.example.appcenter_project.domain.openChat.repository.OpenChatParticipantRepository;
 import com.example.appcenter_project.domain.openChat.repository.OpenChatRoomRepository;
 import com.example.appcenter_project.domain.user.entity.User;
 import com.example.appcenter_project.domain.user.repository.UserRepository;
 import com.example.appcenter_project.global.exception.CustomException;
 import com.example.appcenter_project.global.exception.ErrorCode;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -29,12 +31,27 @@ import java.util.Optional;
 import java.util.Set;
 
 @Service
-@RequiredArgsConstructor
 public class OpenChatRoomService {
 
     private final OpenChatRoomRepository openChatRoomRepository;
     private final OpenChatParticipantRepository openChatParticipantRepository;
+    private final OpenChatMessageRepository openChatMessageRepository;
     private final UserRepository userRepository;
+    private final OpenChatMessageService openChatMessageService;
+
+    @Autowired
+    public OpenChatRoomService(
+            OpenChatRoomRepository openChatRoomRepository,
+            OpenChatParticipantRepository openChatParticipantRepository,
+            OpenChatMessageRepository openChatMessageRepository,
+            UserRepository userRepository,
+            @Lazy OpenChatMessageService openChatMessageService) {
+        this.openChatRoomRepository = openChatRoomRepository;
+        this.openChatParticipantRepository = openChatParticipantRepository;
+        this.openChatMessageRepository = openChatMessageRepository;
+        this.userRepository = userRepository;
+        this.openChatMessageService = openChatMessageService;
+    }
 
     @Transactional
     public Long createRoom(RequestCreateOpenChatRoomDto request, Long userId) {
@@ -66,7 +83,7 @@ public class OpenChatRoomService {
     public Page<ResponseOpenChatRoomDto> getRooms(Long userId, OpenChatRoomTab tab, Pageable pageable) {
         if (tab == OpenChatRoomTab.MY) {
             List<OpenChatRoom> rooms = openChatRoomRepository.findMyRooms(userId);
-            return toPageDto(rooms, userId, pageable);
+            return toPageDtoWithUnread(rooms, userId, pageable);
         } else if (tab == OpenChatRoomTab.ALL) {
             List<OpenChatRoom> rooms = openChatRoomRepository.findAllPublicRooms();
             return toPageDto(rooms, userId, pageable);
@@ -108,6 +125,11 @@ public class OpenChatRoomService {
         }
 
         openChatParticipantRepository.save(OpenChatParticipant.create(roomId, userId, LocalDateTime.now()));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        openChatMessageService.sendSystemMessage(roomId, user.getName() + "님이 입장했습니다.");
+
         return toDetailDto(room, roomId);
     }
 
@@ -120,7 +142,12 @@ public class OpenChatRoomService {
                 .findByRoomIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.OPEN_CHAT_PARTICIPANT_NOT_FOUND));
 
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
         openChatParticipantRepository.delete(participant);
+
+        openChatMessageService.sendSystemMessage(roomId, user.getName() + "님이 퇴장했습니다.");
 
         if (userId.equals(room.getHostUserId())) {
             return handleHostLeave(room);
@@ -175,6 +202,28 @@ public class OpenChatRoomService {
                         room,
                         countMap.getOrDefault(room.getId(), 0L).intValue(),
                         joinedRoomIds.contains(room.getId())))
+                .toList();
+        return new PageImpl<>(dtos, pageable, dtos.size());
+    }
+
+    private Page<ResponseOpenChatRoomDto> toPageDtoWithUnread(List<OpenChatRoom> rooms, Long userId, Pageable pageable) {
+        if (rooms.isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), pageable, 0);
+        }
+        List<Long> roomIds = rooms.stream().map(OpenChatRoom::getId).toList();
+        Map<Long, Long> countMap = openChatParticipantRepository.countByRoomIds(roomIds);
+        Set<Long> joinedRoomIds = openChatParticipantRepository.findJoinedRoomIds(userId, roomIds);
+        Map<Long, Long> lastReadMap = openChatParticipantRepository.findLastReadMessageIdsByUserId(userId, roomIds);
+        List<ResponseOpenChatRoomDto> dtos = rooms.stream()
+                .map(room -> {
+                    Long lastReadMessageId = lastReadMap.get(room.getId());
+                    int unreadCount = (int) openChatMessageRepository.countByRoomIdAndIdGreaterThan(room.getId(), lastReadMessageId);
+                    return ResponseOpenChatRoomDto.from(
+                            room,
+                            countMap.getOrDefault(room.getId(), 0L).intValue(),
+                            joinedRoomIds.contains(room.getId()),
+                            unreadCount);
+                })
                 .toList();
         return new PageImpl<>(dtos, pageable, dtos.size());
     }

--- a/src/main/java/com/example/appcenter_project/global/config/OpenChatWebSocketEventListener.java
+++ b/src/main/java/com/example/appcenter_project/global/config/OpenChatWebSocketEventListener.java
@@ -1,0 +1,69 @@
+package com.example.appcenter_project.global.config;
+
+import com.example.appcenter_project.domain.openChat.repository.OpenChatMessageRepository;
+import com.example.appcenter_project.domain.openChat.repository.OpenChatParticipantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OpenChatWebSocketEventListener {
+
+    private final OpenChatMessageRepository openChatMessageRepository;
+    private final OpenChatParticipantRepository openChatParticipantRepository;
+
+    private static final Map<String, Long> sessionRoomMap = new ConcurrentHashMap<>();
+    private static final Map<String, Long> sessionUserMap = new ConcurrentHashMap<>();
+
+    @EventListener
+    public void handleSubscribe(SessionSubscribeEvent event) {
+        MessageHeaders headers = event.getMessage().getHeaders();
+        String destination = SimpMessageHeaderAccessor.getDestination(headers);
+        if (destination == null || !destination.startsWith("/sub/openchat/")) return;
+
+        String sessionId = SimpMessageHeaderAccessor.getSessionId(headers);
+
+        String roomIdStr = destination.substring("/sub/openchat/".length());
+        Long roomId;
+        try {
+            roomId = Long.parseLong(roomIdStr);
+        } catch (NumberFormatException e) {
+            return;
+        }
+
+        Map<String, Object> sessionAttributes = SimpMessageHeaderAccessor.getSessionAttributes(headers);
+        if (sessionAttributes == null) return;
+        String userIdStr = (String) sessionAttributes.get("userId");
+        if (userIdStr == null) return;
+        Long userId;
+        try {
+            userId = Long.parseLong(userIdStr);
+        } catch (NumberFormatException e) {
+            return;
+        }
+
+        sessionRoomMap.put(sessionId, roomId);
+        sessionUserMap.put(sessionId, userId);
+
+        openChatMessageRepository.findLatestMessageIdByRoomId(roomId)
+                .ifPresent(latestId ->
+                        openChatParticipantRepository.updateLastReadMessageId(roomId, userId, latestId));
+    }
+
+    @EventListener
+    public void handleDisconnect(SessionDisconnectEvent event) {
+        String sessionId = event.getSessionId();
+        sessionRoomMap.remove(sessionId);
+        sessionUserMap.remove(sessionId);
+    }
+}

--- a/src/main/java/com/example/appcenter_project/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/appcenter_project/global/exception/ErrorCode.java
@@ -166,6 +166,7 @@ public enum ErrorCode {
     OPEN_CHAT_ROOM_FORBIDDEN(FORBIDDEN, 22002, "[OpenChat] 채팅방 접근 권한이 없습니다."),
     OPEN_CHAT_ROOM_FULL(BAD_REQUEST, 22003, "[OpenChat] 최대 인원에 도달한 채팅방입니다."),
     OPEN_CHAT_PARTICIPANT_NOT_FOUND(NOT_FOUND, 22004, "[OpenChat] 참여하지 않은 채팅방입니다."),
+    OPEN_CHAT_NOT_PARTICIPANT(FORBIDDEN, 22005, "[OpenChat] 채팅 내역 조회 권한이 없습니다."),
 
     // RATE LIMIT
     RATE_LIMIT_EXCEEDED(TOO_MANY_REQUESTS, 20001, "[RateLimit] 요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."),

--- a/src/main/resources/db/migration/V8__open_chat_phase2.sql
+++ b/src/main/resources/db/migration/V8__open_chat_phase2.sql
@@ -1,0 +1,5 @@
+ALTER TABLE open_chat_room
+    ADD COLUMN last_message VARCHAR(500) NULL;
+
+ALTER TABLE open_chat_participant
+    ADD COLUMN last_read_message_id BIGINT NULL;

--- a/src/test/java/com/example/appcenter_project/domain/openChat/fixture/OpenChatRoomFixture.java
+++ b/src/test/java/com/example/appcenter_project/domain/openChat/fixture/OpenChatRoomFixture.java
@@ -133,7 +133,8 @@ public class OpenChatRoomFixture {
                 .maxParticipants(10)
                 .isJoined(false)
                 .lastMessageAt(null)
-                .lastMessagePreview(null)
+                .lastMessage(null)
+                .unreadCount(0)
                 .build();
     }
 


### PR DESCRIPTION
## 개요
오픈채팅 Phase 2 — WebSocket + STOMP 기반 실시간 채팅 기능 구현.
메시지 송수신, DB 저장, 구독자 브로드캐스트, 커서 기반 채팅 내역 조회, MY 탭 최신 메시지 미리보기 및 미읽음 수를 포함한다.

## 주요 변경 사항

### Entity / DB
- `OpenChatMessageType`: `SYSTEM` 타입 추가 (입장/퇴장 시스템 메시지)
- `OpenChatRoom`: `last_message VARCHAR(500)` 필드 추가, `updateLastMessage()` 메서드 추가
- `OpenChatParticipant`: `last_read_message_id BIGINT` 필드 추가, `updateLastReadMessageId()` 메서드 추가
- `V8__open_chat_phase2.sql`: Flyway 마이그레이션

### Repository
- `OpenChatMessageQuerydslRepository` + Impl: 커서 기반 페이지네이션, 최신 메시지 ID 조회, 미읽음 count
- `OpenChatParticipantQuerydslRepository` + Impl: `findLastReadMessageIdsByUserId`, `countReadByRoomIdAndMessageId` 추가
- `OpenChatParticipantRepository`: `@Modifying updateLastReadMessageId`, `countByRoomId` 추가
- `OpenChatRoomQuerydslRepositoryImpl`: `findMyRooms` 정렬 `lastMessageAt DESC NULLS LAST` 적용

### Service
- `OpenChatMessageService` (신규): `sendMessage`, `sendSystemMessage`(REQUIRES_NEW), `getMessages`, `calculateUnreadCount`
- `OpenChatRoomService`: `@Lazy OpenChatMessageService` 주입, `joinRoom`/`leaveRoom` 시스템 메시지 발행, MY 탭 unreadCount 계산

### Controller / WebSocket
- `OpenChatMessageController` (신규): `@MessageMapping("/openchat/socketchat")` + `GET /open-chat-rooms/{roomId}/messages`
- `OpenChatWebSocketEventListener` (신규): `/sub/openchat/` 구독 시 `lastReadMessageId` 갱신

### DTO
- `RequestOpenChatMessageDto`, `ResponseOpenChatMessageDto`, `ResponseOpenChatMessageListDto` 신규
- `ResponseOpenChatRoomDto`: `lastMessage`, `unreadCount` 필드 추가

## 설계 결정
- 순환 의존(`OpenChatRoomService` ↔ `OpenChatMessageService`): `@Lazy` 주입으로 해결
- 시스템 메시지: `Propagation.REQUIRES_NEW` — 입장/퇴장 트랜잭션 실패와 격리

## 관련 이슈
Closes #632