### PR TITLE
feat: 오픈채팅 강퇴 사유 필수화 및 비공식 방 단독 방장 자진 퇴장 시 방 삭제 #659

### DIFF
--- a/specs/BR-659-openchat-exit-completion/api-spec.md
+++ b/specs/BR-659-openchat-exit-completion/api-spec.md
@@ -1,0 +1,151 @@
+# 오픈채팅 퇴장(BR-659) API 명세서
+
+> Base URL: `https://{host}/open-chat-rooms`
+> 인증: 모든 엔드포인트 Bearer Token 필요
+
+---
+
+## 강제퇴장
+
+| 항목 | 내용 |
+|------|------|
+| **메서드** | `DELETE` |
+| **경로** | `/open-chat-rooms/{roomId}/participants/{targetUserId}` |
+| **인증** | Bearer Token |
+| **설명** | 방장 또는 ADMIN이 특정 참여자를 강제퇴장시킨다. BR-659 변경: `reason` 필수 파라미터 추가, ADMIN이 방장 강퇴 시 `newHostUserId` 조건부 필수 |
+
+### Request
+
+#### Path Parameters
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|------|------|
+| `roomId` | `Long` | ✅ | 채팅방 ID |
+| `targetUserId` | `Long` | ✅ | 강퇴 대상 사용자 ID |
+
+#### Query Parameters
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|------|------|
+| `reason` | `KickReason` | ✅ | 강퇴 사유 (enum) |
+| `newHostUserId` | `Long` | 조건부 ✅ | ADMIN이 방장을 강퇴할 때, 남은 참여자가 있으면 필수 |
+
+**KickReason 허용값**
+
+| 값 | 의미 |
+|----|------|
+| `SPAM` | 도배/광고 |
+| `ABUSE` | 욕설/비방 |
+| `IMPERSONATION` | 사칭 |
+| `REPORT_ACCUMULATED` | 신고 누적 |
+| `OTHER` | 기타 |
+
+### Response
+
+#### 성공 응답 — `204 No Content`
+
+응답 Body 없음.
+
+#### 에러 응답
+
+| 상태 코드 | ErrorCode | code | 발생 조건 |
+|-----------|-----------|------|-----------|
+| `400 Bad Request` | `OPEN_CHAT_NEW_HOST_REQUIRED` | 22018 | ADMIN이 방장 강퇴 시 `newHostUserId` 누락 + 다른 참여자 있음 |
+| `400 Bad Request` | `OPEN_CHAT_ALREADY_HOST` | 22015 | `newHostUserId`가 이미 방장인 사용자 |
+| `403 Forbidden` | `OPEN_CHAT_KICK_FORBIDDEN` | 22017 | 권한 없음 (일반 참여자 강퇴 시도, 방장이 다른 방장 강퇴 시도, 자기 자신 강퇴 시도, ADMIN 강퇴 시도) |
+| `404 Not Found` | `OPEN_CHAT_ROOM_NOT_FOUND` | 22001 | 존재하지 않는 roomId |
+| `404 Not Found` | `OPEN_CHAT_PARTICIPANT_NOT_FOUND` | 22004 | targetUserId 또는 newHostUserId가 해당 방 미참여자 |
+
+**에러 응답 형식**
+
+```json
+{
+  "code": 22018,
+  "name": "OPEN_CHAT_NEW_HOST_REQUIRED",
+  "message": "[OpenChat] 방장 강퇴 시 새 방장을 지정해야 합니다.",
+  "errors": null
+}
+```
+
+#### 시나리오별 동작 요약
+
+| 호출자 | targetUserId 역할 | newHostUserId | 결과 |
+|--------|------------------|---------------|------|
+| 방장 | 일반 참여자 | 무시 | 204, participant 삭제 |
+| 방장 | 다른 방장 | — | 403 `OPEN_CHAT_KICK_FORBIDDEN` |
+| ADMIN | 일반 참여자 | 무시 | 204, participant 삭제 |
+| ADMIN | 방장 (다른 참여자 있음) | 유효한 참여자 ID | 204, 새 방장 지정 + 대상 삭제 |
+| ADMIN | 방장 (다른 참여자 있음) | 없음 | 400 `OPEN_CHAT_NEW_HOST_REQUIRED` |
+| ADMIN | 방장 (방장 혼자) | 무시 | 204, participant + room 삭제 |
+| 누구든 | 자기 자신 | — | 403 `OPEN_CHAT_KICK_FORBIDDEN` |
+| 누구든 | ADMIN | — | 403 `OPEN_CHAT_KICK_FORBIDDEN` |
+
+---
+
+## 자진 퇴장
+
+| 항목 | 내용 |
+|------|------|
+| **메서드** | `DELETE` |
+| **경로** | `/open-chat-rooms/{roomId}/participants/me` |
+| **인증** | Bearer Token |
+| **설명** | 현재 사용자가 채팅방을 자진 퇴장한다. BR-659 변경: 비공식 방에서 방장 혼자 남은 경우 방 하드 삭제 후 `roomDeleted: true` 반환 |
+
+### Request
+
+#### Path Parameters
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|------|------|
+| `roomId` | `Long` | ✅ | 채팅방 ID |
+
+#### Query Parameters
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|------|------|
+| `newHostUserId` | `Long` | 조건부 ✅ | 방장이 자진 퇴장 시 새 방장 지정. 방장 + 다른 참여자 있음일 때 필수 |
+
+### Response
+
+#### 성공 응답 — `200 OK`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `roomDeleted` | `Boolean` | 방 삭제 여부. 비공식 방에서 방장 혼자 퇴장 시 `true`, 나머지는 `false` |
+
+```json
+{ "roomDeleted": false }
+```
+
+```json
+{ "roomDeleted": true }
+```
+
+#### 에러 응답
+
+| 상태 코드 | ErrorCode | code | 발생 조건 |
+|-----------|-----------|------|-----------|
+| `400 Bad Request` | `OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE` | 22016 | ① 비공식 방에서 방장 + 다른 참여자 있음 + `newHostUserId` 없음 ② 공식 방(`isOfficial=true`)에서 방장 혼자 퇴장 |
+| `400 Bad Request` | `OPEN_CHAT_ALREADY_HOST` | 22015 | `newHostUserId`가 이미 방장 또는 자기 자신 |
+| `403 Forbidden` | `OPEN_CHAT_ROOM_FORBIDDEN` | 22002 | 방장이 아닌 사용자가 `newHostUserId` 전달 |
+| `404 Not Found` | `OPEN_CHAT_PARTICIPANT_NOT_FOUND` | 22004 | 해당 방 미참여자 또는 `newHostUserId`가 미참여자 |
+
+#### 시나리오별 동작 요약
+
+| 호출자 역할 | 방 종류 | 남은 참여자 | newHostUserId | 결과 |
+|------------|--------|-------------|---------------|------|
+| 일반 참여자 | 무관 | 무관 | 무관 | `{ roomDeleted: false }` |
+| 방장 | 무관 | 다른 방장 있음 | 무관 | `{ roomDeleted: false }` |
+| 방장 (sole host) | 비공식 | 없음 (혼자) | 무관 | `{ roomDeleted: true }`, room + participant 삭제 |
+| 방장 (sole host) | 공식 | 없음 (혼자) | 무관 | 400 `OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE` |
+| 방장 (sole host) | 무관 | 다른 참여자 있음 | 유효한 참여자 ID | `{ roomDeleted: false }`, 새 방장 지정 후 퇴장 |
+| 방장 (sole host) | 무관 | 다른 참여자 있음 | 없음 | 400 `OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE` |
+
+---
+
+## 추론 항목
+
+> 코드에서 명시적으로 확인되지 않아 추론한 항목입니다.
+
+- **`reason` 누락 시 응답**: `MissingServletRequestParameterException` 발생. 현재 `GlobalExceptionHandler`에 해당 핸들러 없어 `handleUnexpectedException`(500)으로 떨어질 수 있음. `/implement` 단계에서 핸들러 추가 또는 명시적 검증 처리 권장.
+- **`reason` 잘못된 enum 값**: `MethodArgumentTypeMismatchException` 발생 → 동일하게 500. 핸들러 추가 권장.

--- a/specs/BR-659-openchat-exit-completion/design.md
+++ b/specs/BR-659-openchat-exit-completion/design.md
@@ -1,0 +1,195 @@
+# BR-659 — 도메인 설계
+
+## 엔티티 / 값 객체
+
+엔티티 변경 없음. 신규 enum 1개만 추가.
+
+### KickReason (신규 enum)
+
+```java
+package com.example.appcenter_project.domain.openChat.enums;
+
+public enum KickReason {
+    SPAM,
+    ABUSE,
+    IMPERSONATION,
+    REPORT_ACCUMULATED,
+    OTHER
+}
+```
+
+기존 enum(`OpenChatRoomScope`, `OpenChatRoomType`, `OpenChatRoomTab`, `OpenChatMessageType`)과
+동일한 스타일 — 어노테이션 없이 상수만 선언.
+
+---
+
+## 애그리거트 경계
+
+변경 없음. 기존 구조 유지.
+
+- `OpenChatRoom` — 애그리거트 루트
+- `OpenChatParticipant` — `roomId` (Long) ID 참조로 방에 연결. JPA `@ManyToOne` 없음.
+
+---
+
+## 연관관계
+
+변경 없음. 신규 연관관계 없음.
+
+---
+
+## DB 스키마 변경
+
+없음. 엔티티 필드 변경 없으므로 마이그레이션 스크립트 불필요.
+
+---
+
+## 도메인 계층 구조
+
+```
+domain/openChat/
+├── controller/
+│   ├── OpenChatRoomController.java         ← 수정: kickParticipant 파라미터 추가
+│   └── OpenChatRoomApiSpecification.java   ← 수정: kickParticipant 시그니처 동기화
+├── service/
+│   └── OpenChatRoomService.java            ← 수정: kickParticipant, leaveRoom 로직 변경
+├── enums/
+│   └── KickReason.java                     ← 신규
+global/exception/
+└── ErrorCode.java                          ← 수정: OPEN_CHAT_NEW_HOST_REQUIRED 추가
+```
+
+### 신규 생성
+
+| 파일 | 설명 |
+|------|------|
+| `domain/openChat/enums/KickReason.java` | 강제퇴장 사유 enum |
+
+### 수정 대상
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `global/exception/ErrorCode.java` | `OPEN_CHAT_NEW_HOST_REQUIRED(BAD_REQUEST, 22018, ...)` 추가 |
+| `OpenChatRoomService.java` | `@Slf4j` 추가, `kickParticipant` 시그니처·로직 변경, `leaveRoom` 로직 변경 |
+| `OpenChatRoomController.java` | `kickParticipant` — `@RequestParam KickReason reason`, `@RequestParam(required=false) Long newHostUserId` 추가 |
+| `OpenChatRoomApiSpecification.java` | `kickParticipant` 시그니처 동기화 |
+
+---
+
+## 변경 상세
+
+### ErrorCode 추가
+
+```java
+OPEN_CHAT_NEW_HOST_REQUIRED(BAD_REQUEST, 22018, "[OpenChat] 방장 강퇴 시 새 방장을 지정해야 합니다."),
+```
+
+기존 `OPEN_CHAT_KICK_FORBIDDEN(22017)` 바로 다음에 삽입.
+
+---
+
+### OpenChatRoomService — kickParticipant 시그니처
+
+```java
+// 기존
+public void kickParticipant(Long actorId, Long roomId, Long targetUserId)
+
+// 변경
+public void kickParticipant(Long actorId, Long roomId, Long targetUserId,
+                             KickReason reason, Long newHostUserId)
+```
+
+#### 로직 변경 포인트
+
+1. `findByIdWithLock` 반환값을 `room` 변수에 저장 (기존 결과 버림 → 방 삭제에 활용)
+2. ADMIN이 방장을 강퇴할 때 추가 분기 (기존 `if (!isAdmin)` 블록 이후):
+   ```
+   if (isAdmin && targetParticipant.isHost()) {
+       List<OpenChatParticipant> allParticipants = openChatParticipantRepository.findAllByRoomId(roomId);
+       boolean othersExist = allParticipants.size() > 1;
+       if (othersExist) {
+           if (newHostUserId == null) → OPEN_CHAT_NEW_HOST_REQUIRED
+           OpenChatParticipant newHost = findByRoomIdAndUserId(roomId, newHostUserId) → OPEN_CHAT_PARTICIPANT_NOT_FOUND
+           if (newHost.isHost()) → OPEN_CHAT_ALREADY_HOST
+           newHost.grantHost()
+       }
+       openChatParticipantRepository.delete(targetParticipant)
+       if (!othersExist) openChatRoomRepository.delete(room)   // 마지막 참여자 강퇴 → 방 삭제
+   } else {
+       openChatParticipantRepository.delete(targetParticipant) // 기존 흐름
+   }
+   ```
+3. 처리 완료 후 `log.info()` 기록:
+   ```java
+   log.info("[OpenChat-Exit] exitType={} roomId={} targetUserId={} actorId={} reason={} processedAt={}",
+       isAdmin ? "ADMIN_KICK" : "HOST_KICK", roomId, targetUserId, actorId, reason, Instant.now());
+   ```
+4. 시스템 메시지는 방이 삭제된 경우 생략 (참여자 없으므로 의미 없음)
+
+---
+
+### OpenChatRoomService — leaveRoom 로직 변경
+
+변경 대상: `if (self.isHost())` → `hostCount == 1` 분기 내부.
+
+```
+// 기존
+if (hostCount == 1) {
+    throw new CustomException(ErrorCode.OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE);
+}
+
+// 변경
+if (hostCount == 1) {
+    if (lockedParticipants.size() == 1) {
+        // 혼자 남은 방장 — 방 종류에 따라 분기
+        OpenChatRoom room = openChatRoomRepository.findByIdWithLock(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.OPEN_CHAT_ROOM_NOT_FOUND));
+        if (!room.isOfficial()) {
+            openChatParticipantRepository.deleteAll(lockedParticipants);
+            openChatRoomRepository.delete(room);
+            log.info("[OpenChat-Exit] exitType=VOLUNTARY roomId={} targetUserId={} actorId={} processedAt={}",
+                roomId, userId, userId, Instant.now());
+            return ResponseLeaveOpenChatRoomDto.builder().roomDeleted(true).build();
+        }
+    }
+    throw new CustomException(ErrorCode.OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE);
+}
+```
+
+자진 퇴장 성공(방 삭제 없는 경우)에도 동일 필드 로그 추가:
+```java
+log.info("[OpenChat-Exit] exitType=VOLUNTARY roomId={} targetUserId={} actorId={} processedAt={}",
+    roomId, userId, userId, Instant.now());
+```
+
+---
+
+### OpenChatRoomController — kickParticipant 파라미터 추가
+
+```java
+@DeleteMapping("/{roomId}/participants/{targetUserId}")
+public ResponseEntity<Void> kickParticipant(
+        @AuthenticationPrincipal CustomUserDetails user,
+        @PathVariable Long roomId,
+        @PathVariable Long targetUserId,
+        @RequestParam KickReason reason,
+        @RequestParam(required = false) Long newHostUserId) {
+    openChatRoomService.kickParticipant(user.getId(), roomId, targetUserId, reason, newHostUserId);
+    return ResponseEntity.noContent().build();
+}
+```
+
+`reason`은 `@RequestParam`(required 기본값 true) → 누락 시 Spring이 400 자동 반환.
+
+---
+
+## 비목표
+
+requirement.md 비목표를 그대로 따른다.
+
+- `OpenChatParticipant`에 `isBanned` 등 강퇴 상태 필드 없음
+- `OpenChatRoom`에 `status(OPEN/CLOSED)` enum 없음
+- `OpenChatExitLog` 엔티티·테이블 없음
+- WebSocket STOMP 세션 강제 종료 없음
+- `KickReason.OTHER` 선택 시 추가 텍스트 입력 없음
+- 기존 권한 체크 조건(방장·ADMIN 판별) 변경 없음

--- a/specs/BR-659-openchat-exit-completion/requirement.md
+++ b/specs/BR-659-openchat-exit-completion/requirement.md
@@ -1,0 +1,160 @@
+# BR-659 — 오픈채팅 퇴장 기능 미구현 항목 완성
+
+## 기능 요약
+
+기존 오픈채팅 퇴장(자진/강제) API에서 누락된 항목을 완성한다.  
+① 강제퇴장 사유(enum) 파라미터 추가 ② 운영 로그(logger) 기록 ③ 방장 단독 자진 퇴장 시 방 하드 삭제 ④ 관리자가 방장을 강퇴할 때 새 방장 지정 필수 + 후속 처리.
+
+---
+
+## 동작 명세
+
+### 1. 강제퇴장 사유 파라미터 추가 (`kickParticipant`)
+
+- **입력**: `reason: KickReason` (요청 쿼리 파라미터, 필수)
+- **처리**: 기존 권한 체크 및 participant 삭제 로직은 동일. reason 값을 운영 로그에 포함.
+- **출력**: 변경 없음 (204 No Content)
+
+### 2. 관리자가 방장을 강퇴할 때 신규 파라미터 (`kickParticipant`)
+
+- **입력**: `newHostUserId: Long` (요청 쿼리 파라미터, 조건부 필수)
+- **처리 흐름**:
+  1. ADMIN이 방장(`isHost=true`)을 강퇴 요청
+  2. 방에 다른 참여자가 있으면:
+     - `newHostUserId` 없으면 → `OPEN_CHAT_NEW_HOST_REQUIRED` 에러
+     - `newHostUserId` 있으면 → 해당 참여자에게 `grantHost()` 후 target participant 삭제
+  3. 방에 다른 참여자가 없으면 (방장 혼자):
+     - `newHostUserId` 무시, participant + room 하드 삭제
+- **출력**: 204 No Content
+
+### 3. 방장 단독 자진 퇴장 시 방 하드 삭제 (`leaveRoom`)
+
+- **현행**: 방장 혼자 남았을 때 `OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE` 예외 발생
+- **변경**: 비공식(user-created) 방에서 방장이 마지막 참여자이면 participant + room 하드 삭제 후 `roomDeleted: true` 반환
+- **처리 흐름**:
+  1. `newHostUserId == null` && `self.isHost() == true` 진입
+  2. `lockedParticipants.size() == 1` (자신만 남음) && `room.isOfficial() == false`
+     → `openChatParticipantRepository.deleteAll(lockedParticipants)` + `openChatRoomRepository.delete(room)`
+     → `ResponseLeaveOpenChatRoomDto(roomDeleted: true)` 반환
+  3. 공식 방(`isOfficial == true`)에서 마지막 참여자 퇴장:
+     → 기존 예외(`OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE`) 유지
+  4. 방장이 혼자지만 다른 방장이 있는 경우(multi-host 구조):
+     → 기존 흐름 유지 (방장 수 > 1이면 자유 퇴장)
+
+### 4. 운영 로그 기록
+
+퇴장 처리 성공 직후, 아래 정보를 `logger.info()`로 기록한다.
+
+| 필드 | 내용 |
+|------|------|
+| exitType | VOLUNTARY / HOST_KICK / ADMIN_KICK |
+| roomId | 방 ID |
+| targetUserId | 퇴장 대상 ID |
+| actorId | 실행자 ID (자진 퇴장 시 targetUserId와 동일) |
+| reason | KickReason enum 값 (자진 퇴장 시 null) |
+| processedAt | `Instant.now()` |
+
+적용 위치: `leaveRoom`, `kickParticipant` 처리 완료 시점.
+
+---
+
+## 도메인 데이터
+
+### KickReason (신규 enum)
+
+```
+SPAM              // 도배/광고
+ABUSE             // 욕설/비방
+IMPERSONATION     // 사칭
+REPORT_ACCUMULATED // 신고 누적
+OTHER             // 기타
+```
+
+위치: `domain/openChat/enums/KickReason.java`
+
+### 변경되는 기존 데이터
+
+- `OpenChatParticipant`: 변경 없음 (강퇴 상태 필드 추가 없음 — 재입장 차단은 이번 범위 밖)
+- `OpenChatRoom`: 변경 없음 (status 필드 추가 없음 — 방 종료는 하드 삭제로 처리)
+- `ResponseLeaveOpenChatRoomDto`: `roomDeleted` 필드 이미 존재 — 그대로 활용
+
+---
+
+## 비즈니스 규칙 / 제약
+
+### kickParticipant 변경 규칙
+
+1. `reason`은 모든 강제퇴장 요청(방장·관리자 불문)에서 필수값이다.
+2. `newHostUserId`는 ADMIN이 방장을 강퇴할 때만 의미 있다. 방장이 일반 참여자를 강퇴할 때 `newHostUserId`가 전달되어도 무시한다.
+3. ADMIN이 방장을 강퇴할 때:
+   - 다른 참여자가 있으면 `newHostUserId` 필수
+   - `newHostUserId`가 방 미참여자이면 → `OPEN_CHAT_PARTICIPANT_NOT_FOUND`
+   - `newHostUserId`가 이미 방장이면 → `OPEN_CHAT_ALREADY_HOST`
+   - 다른 참여자가 없으면 `newHostUserId` 불필요, 방 삭제
+
+### leaveRoom 변경 규칙
+
+4. 비공식 방에서 마지막 참여자(== 방장)가 자진 퇴장하면 방을 하드 삭제한다.
+5. 공식 방(`isOfficial=true`)은 참여자가 없어도 방이 유지되어야 하므로 기존 예외를 유지한다.
+6. multi-host 구조(방장이 둘 이상)에서 방장 중 한 명이 퇴장하는 것은 영향 없음(기존 흐름).
+
+---
+
+## 예외 · 경계 상황
+
+| 상황 | 기대 동작 |
+|------|-----------|
+| `reason` 없이 강제퇴장 요청 | 400 BAD_REQUEST |
+| ADMIN이 방장 강퇴 시 `newHostUserId` 누락 + 다른 참여자 있음 | 400 BAD_REQUEST (`OPEN_CHAT_NEW_HOST_REQUIRED`) |
+| ADMIN이 방장 강퇴 시 `newHostUserId`가 방 미참여자 | 404 (`OPEN_CHAT_PARTICIPANT_NOT_FOUND`) |
+| ADMIN이 방장 강퇴 시 `newHostUserId`가 이미 방장 | 409 (`OPEN_CHAT_ALREADY_HOST`) |
+| 비공식 방 마지막 방장 자진 퇴장 | 200 + `roomDeleted: true` |
+| 공식 방 마지막 방장 자진 퇴장 | 403 (`OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE`) |
+| `newHostUserId` 없이 leaveRoom 요청 (방장 + 다른 참여자 있음) | 기존 흐름 (`OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE`) |
+
+---
+
+## 비목표 (Non-goals)
+
+- **강퇴 후 재입장 차단**: `OpenChatParticipant`에 banned 상태 필드 추가 안 함
+- **DB 운영 로그 테이블**: `open_chat_exit_log` 엔티티 생성 안 함. `logger.info()` 만 사용
+- **방 status 필드**: `OpenChatRoom`에 OPEN/CLOSED 상태 enum 추가 안 함. 종료는 하드 삭제
+- **WebSocket 구독 강제 해제**: 서버 측 STOMP 세션 강제 종료 로직 추가 안 함
+- **강퇴 사유 자유입력(String)**: enum 선택지만 지원
+- **기존 `kickParticipant` 권한 체크 변경**: 방장·ADMIN 권한 조건은 현행 유지
+
+---
+
+## 수용 기준 (Acceptance Criteria)
+
+### KickReason enum
+
+- **Given** `KickReason` enum이 존재할 때 **When** 각 상수(SPAM, ABUSE, IMPERSONATION, REPORT_ACCUMULATED, OTHER)를 조회 **Then** 컴파일 오류 없이 반환된다
+
+### kickParticipant — reason 필수
+
+- **Given** 방장이 일반 참여자를 강퇴할 때 **When** `reason=SPAM` 포함 요청 **Then** 204 반환, 시스템 메시지 발송
+- **Given** 강제퇴장 요청에 **When** `reason` 없으면 **Then** 400 반환
+
+### kickParticipant — ADMIN이 방장 강퇴 (다른 참여자 있음)
+
+- **Given** 방에 방장A + 일반참여자B, ADMIN이 방장A를 강퇴 요청 **When** `newHostUserId=B, reason=ABUSE` **Then** B에게 방장 권한 부여, A participant 삭제, 시스템 메시지 발송
+- **Given** 방에 방장A + 일반참여자B, ADMIN이 방장A를 강퇴 요청 **When** `newHostUserId` 없음 **Then** `OPEN_CHAT_NEW_HOST_REQUIRED` 에러
+
+### kickParticipant — ADMIN이 방장 강퇴 (마지막 참여자)
+
+- **Given** 방에 방장A만 존재, ADMIN이 방장A를 강퇴 요청 **When** `reason=OTHER` **Then** participant 삭제 + room 삭제
+
+### leaveRoom — 비공식 방 마지막 방장 자진 퇴장
+
+- **Given** 비공식 방에 방장A 혼자 **When** `leaveRoom(roomId, A, null)` **Then** participant + room 모두 삭제, `roomDeleted: true` 반환
+- **Given** 비공식 방에 방장A + 참여자B **When** `leaveRoom(roomId, A, null)` **Then** `OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE` (기존 동작 유지)
+
+### leaveRoom — 공식 방 마지막 방장 자진 퇴장
+
+- **Given** 공식 방에 방장A 혼자 **When** `leaveRoom(roomId, A, null)` **Then** `OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE` (방 유지)
+
+### 운영 로그
+
+- **Given** 강제퇴장 성공 시 **When** 처리 완료 **Then** `logger.info()`에 exitType/roomId/targetUserId/actorId/reason/processedAt 포함
+- **Given** 자진 퇴장 성공 시 **When** 처리 완료 **Then** `logger.info()`에 exitType=VOLUNTARY/roomId/targetUserId/processedAt 포함

--- a/src/main/java/com/example/appcenter_project/domain/openChat/controller/OpenChatRoomApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/controller/OpenChatRoomApiSpecification.java
@@ -5,6 +5,7 @@ import com.example.appcenter_project.domain.openChat.dto.response.ResponseLeaveO
 import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatParticipantListDto;
 import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatRoomDetailDto;
 import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatRoomDto;
+import com.example.appcenter_project.domain.openChat.enums.KickReason;
 import com.example.appcenter_project.domain.openChat.enums.OpenChatRoomTab;
 import com.example.appcenter_project.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -84,5 +85,7 @@ public interface OpenChatRoomApiSpecification {
     ResponseEntity<Void> kickParticipant(
             @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long roomId,
-            @PathVariable Long targetUserId);
+            @PathVariable Long targetUserId,
+            @RequestParam KickReason reason,
+            @RequestParam(required = false) Long newHostUserId);
 }

--- a/src/main/java/com/example/appcenter_project/domain/openChat/controller/OpenChatRoomController.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/controller/OpenChatRoomController.java
@@ -5,6 +5,7 @@ import com.example.appcenter_project.domain.openChat.dto.response.ResponseLeaveO
 import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatParticipantListDto;
 import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatRoomDetailDto;
 import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatRoomDto;
+import com.example.appcenter_project.domain.openChat.enums.KickReason;
 import com.example.appcenter_project.domain.openChat.enums.OpenChatRoomTab;
 import com.example.appcenter_project.domain.openChat.service.OpenChatRoomService;
 import com.example.appcenter_project.domain.user.entity.User;
@@ -82,8 +83,10 @@ public class OpenChatRoomController implements OpenChatRoomApiSpecification {
     public ResponseEntity<Void> kickParticipant(
             @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long roomId,
-            @PathVariable Long targetUserId) {
-        openChatRoomService.kickParticipant(user.getId(), roomId, targetUserId);
+            @PathVariable Long targetUserId,
+            @RequestParam KickReason reason,
+            @RequestParam(required = false) Long newHostUserId) {
+        openChatRoomService.kickParticipant(user.getId(), roomId, targetUserId, reason, newHostUserId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/example/appcenter_project/domain/openChat/enums/KickReason.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/enums/KickReason.java
@@ -1,0 +1,9 @@
+package com.example.appcenter_project.domain.openChat.enums;
+
+public enum KickReason {
+    SPAM,
+    ABUSE,
+    IMPERSONATION,
+    REPORT_ACCUMULATED,
+    OTHER
+}

--- a/src/main/java/com/example/appcenter_project/domain/openChat/service/OpenChatRoomService.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/service/OpenChatRoomService.java
@@ -10,6 +10,7 @@ import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenCh
 import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatRoomDto;
 import com.example.appcenter_project.domain.openChat.entity.OpenChatParticipant;
 import com.example.appcenter_project.domain.openChat.entity.OpenChatRoom;
+import com.example.appcenter_project.domain.openChat.enums.KickReason;
 import com.example.appcenter_project.domain.openChat.enums.OpenChatRoomScope;
 import com.example.appcenter_project.domain.openChat.enums.OpenChatRoomTab;
 import com.example.appcenter_project.domain.openChat.enums.OpenChatRoomType;
@@ -21,6 +22,7 @@ import com.example.appcenter_project.domain.user.enums.Role;
 import com.example.appcenter_project.domain.user.repository.UserRepository;
 import com.example.appcenter_project.global.exception.CustomException;
 import com.example.appcenter_project.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
@@ -29,6 +31,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +39,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 public class OpenChatRoomService {
 
@@ -187,12 +191,25 @@ public class OpenChatRoomService {
                     .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
             openChatMessageService.sendSystemMessage(roomId, user.getName() + "님이 퇴장했습니다.");
 
+            log.info("[OpenChat-Exit] exitType=VOLUNTARY roomId={} targetUserId={} actorId={} processedAt={}",
+                    roomId, userId, userId, Instant.now());
             return ResponseLeaveOpenChatRoomDto.builder().roomDeleted(false).build();
         }
 
         if (self.isHost()) {
             long hostCount = lockedParticipants.stream().filter(OpenChatParticipant::isHost).count();
             if (hostCount == 1) {
+                if (lockedParticipants.size() == 1) {
+                    OpenChatRoom room = openChatRoomRepository.findByIdWithLock(roomId)
+                            .orElseThrow(() -> new CustomException(ErrorCode.OPEN_CHAT_ROOM_NOT_FOUND));
+                    if (!room.isOfficial()) {
+                        openChatParticipantRepository.deleteAll(lockedParticipants);
+                        openChatRoomRepository.delete(room);
+                        log.info("[OpenChat-Exit] exitType=VOLUNTARY roomId={} targetUserId={} actorId={} processedAt={}",
+                                roomId, userId, userId, Instant.now());
+                        return ResponseLeaveOpenChatRoomDto.builder().roomDeleted(true).build();
+                    }
+                }
                 throw new CustomException(ErrorCode.OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE);
             }
         }
@@ -203,6 +220,8 @@ public class OpenChatRoomService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         openChatMessageService.sendSystemMessage(roomId, user.getName() + "님이 퇴장했습니다.");
 
+        log.info("[OpenChat-Exit] exitType=VOLUNTARY roomId={} targetUserId={} actorId={} processedAt={}",
+                roomId, userId, userId, Instant.now());
         return ResponseLeaveOpenChatRoomDto.builder().roomDeleted(false).build();
     }
 
@@ -215,8 +234,8 @@ public class OpenChatRoomService {
     }
 
     @Transactional
-    public void kickParticipant(Long actorId, Long roomId, Long targetUserId) {
-        openChatRoomRepository.findByIdWithLock(roomId)
+    public void kickParticipant(Long actorId, Long roomId, Long targetUserId, KickReason reason, Long newHostUserId) {
+        OpenChatRoom room = openChatRoomRepository.findByIdWithLock(roomId)
                 .orElseThrow(() -> new CustomException(ErrorCode.OPEN_CHAT_ROOM_NOT_FOUND));
 
         if (actorId.equals(targetUserId)) {
@@ -227,6 +246,10 @@ public class OpenChatRoomService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         boolean isAdmin = actor.getRole() == Role.ROLE_ADMIN;
 
+        OpenChatParticipant targetParticipant = openChatParticipantRepository
+                .findByRoomIdAndUserId(roomId, targetUserId)
+                .orElseThrow(() -> new CustomException(ErrorCode.OPEN_CHAT_PARTICIPANT_NOT_FOUND));
+
         if (!isAdmin) {
             boolean actorIsHost = openChatParticipantRepository
                     .existsByRoomIdAndUserIdAndIsHost(roomId, actorId, true);
@@ -234,18 +257,10 @@ public class OpenChatRoomService {
                 throw new CustomException(ErrorCode.OPEN_CHAT_KICK_FORBIDDEN);
             }
 
-            OpenChatParticipant targetParticipant = openChatParticipantRepository
-                    .findByRoomIdAndUserId(roomId, targetUserId)
-                    .orElseThrow(() -> new CustomException(ErrorCode.OPEN_CHAT_PARTICIPANT_NOT_FOUND));
-
             if (targetParticipant.isHost()) {
                 throw new CustomException(ErrorCode.OPEN_CHAT_KICK_FORBIDDEN);
             }
         }
-
-        OpenChatParticipant targetParticipant = openChatParticipantRepository
-                .findByRoomIdAndUserId(roomId, targetUserId)
-                .orElseThrow(() -> new CustomException(ErrorCode.OPEN_CHAT_PARTICIPANT_NOT_FOUND));
 
         User targetUser = userRepository.findById(targetUserId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -254,8 +269,34 @@ public class OpenChatRoomService {
             throw new CustomException(ErrorCode.OPEN_CHAT_KICK_FORBIDDEN);
         }
 
-        openChatParticipantRepository.delete(targetParticipant);
-        openChatMessageService.sendSystemMessage(roomId, targetUser.getName() + "님이 강제퇴장되었습니다.");
+        if (isAdmin && targetParticipant.isHost()) {
+            List<OpenChatParticipant> allParticipants = openChatParticipantRepository.findAllByRoomId(roomId);
+            boolean othersExist = allParticipants.size() > 1;
+            if (othersExist) {
+                if (newHostUserId == null) {
+                    throw new CustomException(ErrorCode.OPEN_CHAT_NEW_HOST_REQUIRED);
+                }
+                OpenChatParticipant newHost = openChatParticipantRepository
+                        .findByRoomIdAndUserId(roomId, newHostUserId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.OPEN_CHAT_PARTICIPANT_NOT_FOUND));
+                if (newHost.isHost()) {
+                    throw new CustomException(ErrorCode.OPEN_CHAT_ALREADY_HOST);
+                }
+                newHost.grantHost();
+            }
+            openChatParticipantRepository.delete(targetParticipant);
+            if (!othersExist) {
+                openChatRoomRepository.delete(room);
+            } else {
+                openChatMessageService.sendSystemMessage(roomId, targetUser.getName() + "님이 강제퇴장되었습니다.");
+            }
+        } else {
+            openChatParticipantRepository.delete(targetParticipant);
+            openChatMessageService.sendSystemMessage(roomId, targetUser.getName() + "님이 강제퇴장되었습니다.");
+        }
+
+        log.info("[OpenChat-Exit] exitType={} roomId={} targetUserId={} actorId={} reason={} processedAt={}",
+                isAdmin ? "ADMIN_KICK" : "HOST_KICK", roomId, targetUserId, actorId, reason, Instant.now());
     }
 
     @Transactional

--- a/src/main/java/com/example/appcenter_project/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/appcenter_project/global/exception/ErrorCode.java
@@ -180,6 +180,7 @@ public enum ErrorCode {
     OPEN_CHAT_ALREADY_HOST(BAD_REQUEST, 22015, "[OpenChat] 이미 방장인 사용자입니다."),
     OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE(BAD_REQUEST, 22016, "[OpenChat] 단독 방장은 방 삭제 또는 방장 위임 후 나갈 수 있습니다."),
     OPEN_CHAT_KICK_FORBIDDEN(FORBIDDEN, 22017, "[OpenChat] 강제퇴장 권한이 없습니다."),
+    OPEN_CHAT_NEW_HOST_REQUIRED(BAD_REQUEST, 22018, "[OpenChat] 방장 강퇴 시 새 방장을 지정해야 합니다."),
 
     // STUDENT_ID_DISCLOSURE
     DISCLOSURE_REQUEST_NOT_FOUND(NOT_FOUND, 23001, "[StudentIdDisclosure] 학번 공개 요청을 찾을 수 없습니다."),

--- a/src/main/java/com/example/appcenter_project/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/appcenter_project/global/exception/GlobalExceptionHandler.java
@@ -7,8 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import javax.naming.AuthenticationException;
@@ -41,6 +43,18 @@ public class GlobalExceptionHandler {
 
         log.warn("MethodArgumentNotValidException 발생(DTO): {}", errors);
         return ErrorResponseEntity.toResponseEntity(ErrorCode.VALIDATION_FAILED, "DTO에서 요청한 값이 올바르지 않습니다.", errors);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponseEntity> handleMissingRequestParam(MissingServletRequestParameterException ex) {
+        log.warn("MissingServletRequestParameterException 발생: {}", ex.getMessage());
+        return ErrorResponseEntity.toResponseEntity(ErrorCode.VALIDATION_FAILED);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponseEntity> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        log.warn("MethodArgumentTypeMismatchException 발생: {}", ex.getMessage());
+        return ErrorResponseEntity.toResponseEntity(ErrorCode.VALIDATION_FAILED);
     }
 
     @ExceptionHandler(MissingServletRequestPartException.class)

--- a/src/main/resources/static/chat-test.html
+++ b/src/main/resources/static/chat-test.html
@@ -235,6 +235,32 @@
   </div>
 </div>
 
+<!-- ───────────── 모달: 강제퇴장 사유 선택 ───────────── -->
+<div id="modal-kick" class="modal-overlay" style="display:none">
+  <div class="modal-box">
+    <div class="modal-title">강제퇴장</div>
+    <p id="kick-target-info" style="font-size:13px;margin-bottom:12px;"></p>
+    <div class="form-row">
+      <label>강퇴 사유 (필수)</label>
+      <select id="kick-reason">
+        <option value="SPAM">스팸 (SPAM)</option>
+        <option value="ABUSE">욕설/비방 (ABUSE)</option>
+        <option value="IMPERSONATION">사칭 (IMPERSONATION)</option>
+        <option value="REPORT_ACCUMULATED">신고 누적 (REPORT_ACCUMULATED)</option>
+        <option value="OTHER">기타 (OTHER)</option>
+      </select>
+    </div>
+    <div class="form-row" id="kick-new-host-row" style="display:none">
+      <label>새 방장 userId (방장 강퇴 시 필수)</label>
+      <input type="number" id="kick-new-host-id" placeholder="새 방장으로 지정할 userId">
+    </div>
+    <div class="modal-footer">
+      <button class="btn-secondary" onclick="closeModal('modal-kick')">취소</button>
+      <button class="btn-danger" onclick="doKickParticipant()">강퇴</button>
+    </div>
+  </div>
+</div>
+
 <!-- ───────────── 모달: 방장 위임 후 나가기 ───────────── -->
 <div id="modal-transfer-host" class="modal-overlay" style="display:none">
   <div class="modal-box">
@@ -755,22 +781,21 @@ async function leaveCurrentRoom() {
   if (!currentRoomId) return;
   if (!confirm(`"${currentRoomName}" 방에서 나가시겠습니까?`)) return;
 
-  // 유일 방장인 경우 위임 모달 선제 표시
-  if (currentUserIsHost && currentHostCount === 1) {
-    await openTransferHostModal();
-    return;
-  }
-
+  // 비공식 방 단독 방장이 혼자인 경우 API가 방을 삭제하고 roomDeleted:true 를 반환하므로
+  // 선제 위임 모달 없이 API를 먼저 호출한다.
   try {
     const res = await authFetch(`/open-chat-rooms/${currentRoomId}/participants/me`, { method: 'DELETE' });
     if (res.ok || res.status === 200) {
       const body = await res.json().catch(() => ({}));
-      log(`방 나가기 완료 (roomDeleted: ${body.roomDeleted ?? false})`, 'ok');
+      if (body.roomDeleted) {
+        log('방 나가기 완료 (비공식 방이 삭제되었습니다)', 'ok');
+      } else {
+        log('방 나가기 완료', 'ok');
+      }
       resetChatPanel();
     } else {
       const errText = await res.text();
       log(`방 나가기 실패 (${res.status}): ${errText}`, 'err');
-      // 방장 단독 나가기 실패인 경우 위임 모달 표시
       if (currentUserIsHost) {
         log('방장 위임이 필요합니다.', 'info');
         await openTransferHostModal();
@@ -928,12 +953,12 @@ function renderParticipants(participants, total, hostCount) {
         } else {
           actions += `<button class="btn-xs btn-primary" onclick="grantHostToUser(${p.userId}, '${escHtml(p.nickname)}')">방장추가</button>`;
         }
-        actions += `<button class="btn-xs btn-danger" onclick="kickParticipantUser(${p.userId}, '${escHtml(p.nickname)}')">강퇴</button>`;
+        actions += `<button class="btn-xs btn-danger" onclick="kickParticipantUser(${p.userId}, '${escHtml(p.nickname)}', ${!!p.isHost})">강퇴</button>`;
       } else if (currentUserIsHost && !p.isAdmin) {
         if (!p.isHost) {
           actions += `<button class="btn-xs btn-primary" onclick="grantHostToUser(${p.userId}, '${escHtml(p.nickname)}')">방장추가</button>`;
           actions += `<button class="btn-xs btn-warning" onclick="transferHostToUser(${p.userId}, '${escHtml(p.nickname)}')">방장위임</button>`;
-          actions += `<button class="btn-xs btn-danger" onclick="kickParticipantUser(${p.userId}, '${escHtml(p.nickname)}')">강제퇴장</button>`;
+          actions += `<button class="btn-xs btn-danger" onclick="kickParticipantUser(${p.userId}, '${escHtml(p.nickname)}', false)">강제퇴장</button>`;
         }
       }
     }
@@ -949,16 +974,44 @@ function renderParticipants(participants, total, hostCount) {
 }
 
 // ═══════════════════════════════════════════════════════
-//  강제퇴장 (방장 전용)
+//  강제퇴장 (방장/ADMIN 전용) — BR-659: reason 필수, newHostUserId 옵션
 // ═══════════════════════════════════════════════════════
-async function kickParticipantUser(targetUserId, nickname) {
+let kickTargetUserId = null;
+let kickTargetNickname = null;
+let kickTargetIsHost = false;
+
+function kickParticipantUser(targetUserId, nickname, isHost = false) {
   if (!currentRoomId) return;
-  if (!confirm(`${nickname}님을 강제퇴장하시겠습니까?`)) return;
+  kickTargetUserId = targetUserId;
+  kickTargetNickname = nickname;
+  kickTargetIsHost = isHost;
+
+  document.getElementById('kick-target-info').textContent = `대상: ${nickname} (userId: ${targetUserId})`;
+
+  // ADMIN이 방장을 강퇴할 때만 새 방장 지정 입력란 표시
+  const newHostRow = document.getElementById('kick-new-host-row');
+  newHostRow.style.display = (isHost && currentUserIsAdmin) ? 'block' : 'none';
+  document.getElementById('kick-new-host-id').value = '';
+
+  closeModal('modal-participants');
+  showModal('modal-kick');
+}
+
+async function doKickParticipant() {
+  if (!currentRoomId || !kickTargetUserId) return;
+  const reason = document.getElementById('kick-reason').value;
+  const newHostInput = document.getElementById('kick-new-host-id').value.trim();
+
+  let url = `/open-chat-rooms/${currentRoomId}/participants/${kickTargetUserId}?reason=${reason}`;
+  if (kickTargetIsHost && currentUserIsAdmin && newHostInput) {
+    url += `&newHostUserId=${newHostInput}`;
+  }
+
+  closeModal('modal-kick');
   try {
-    const res = await authFetch(`/open-chat-rooms/${currentRoomId}/participants/${targetUserId}`, { method: 'DELETE' });
+    const res = await authFetch(url, { method: 'DELETE' });
     if (res.status === 204 || res.ok) {
-      log(`${nickname}님 강제퇴장 완료`, 'ok');
-      closeModal('modal-participants');
+      log(`${kickTargetNickname}님 강제퇴장 완료 (사유: ${reason})`, 'ok');
       showParticipants();
     } else {
       const err = await res.text();

--- a/src/test/java/com/example/appcenter_project/domain/openChat/controller/OpenChatExitCompletionControllerTest.java
+++ b/src/test/java/com/example/appcenter_project/domain/openChat/controller/OpenChatExitCompletionControllerTest.java
@@ -1,0 +1,174 @@
+package com.example.appcenter_project.domain.openChat.controller;
+
+import com.example.appcenter_project.domain.openChat.dto.response.ResponseLeaveOpenChatRoomDto;
+import com.example.appcenter_project.domain.openChat.enums.KickReason;
+import com.example.appcenter_project.domain.openChat.service.OpenChatRoomService;
+import com.example.appcenter_project.domain.user.entity.User;
+import com.example.appcenter_project.domain.user.enums.Role;
+import com.example.appcenter_project.global.exception.SlackErrorNotifier;
+import com.example.appcenter_project.global.security.CustomUserDetails;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/*
+ * BR-659 — 오픈채팅 퇴장 기능 미구현 항목 완성 (Controller 계층)
+ *
+ * 엔드포인트:
+ *   DELETE /open-chat-rooms/{roomId}/participants/{targetUserId}
+ *     - reason (KickReason, @RequestParam, required=true)
+ *     - newHostUserId (Long, @RequestParam, required=false)
+ *   DELETE /open-chat-rooms/{roomId}/participants/me
+ *     - 기존 엔드포인트. 변경 없음 — 서비스 로직 변경으로 응답만 달라짐.
+ *
+ * [Controller TC]
+ * TC-C01: DELETE /open-chat-rooms/{roomId}/participants/{targetUserId}?reason=SPAM → 204 No Content
+ * TC-C02: reason 파라미터 누락 → 400 Bad Request (MissingServletRequestParameterException)
+ * TC-C03: reason에 잘못된 enum 값 전달 → 400 Bad Request (MethodArgumentTypeMismatchException)
+ * TC-C04: DELETE /open-chat-rooms/{roomId}/participants/me → 200 OK, body: { "roomDeleted": true }
+ *         (비공식 방 단독 방장 자진 퇴장 시나리오)
+ * TC-C05: 미인증 요청 → 401 Unauthorized (addFilters=true 필요, 별도 테스트 클래스로 분리)
+ */
+@WebMvcTest(OpenChatRoomController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class OpenChatExitCompletionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OpenChatRoomService openChatRoomService;
+
+    @MockBean
+    private SlackErrorNotifier slackErrorNotifier;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    private static final Long ROOM_ID = 1L;
+    private static final Long TARGET_USER_ID = 20L;
+    private static final Long MOCK_USER_ID = 10L;
+
+    @BeforeEach
+    void setUp() {
+        User mockUser = mock(User.class);
+        given(mockUser.getId()).willReturn(MOCK_USER_ID);
+        given(mockUser.getRole()).willReturn(Role.ROLE_USER);
+        CustomUserDetails userDetails = new CustomUserDetails(mockUser);
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // ============================================================
+    // TC-C01: reason=SPAM → 204 No Content
+    // ============================================================
+
+    @Test
+    @DisplayName("강퇴 성공 — TC-C01: reason=SPAM 포함 DELETE 요청 → 204 No Content")
+    void should_return_204_when_kick_request_includes_reason() throws Exception {
+        // given
+        willDoNothing().given(openChatRoomService)
+            .kickParticipant(any(), eq(ROOM_ID), eq(TARGET_USER_ID), eq(KickReason.SPAM), isNull());
+
+        // when
+        ResultActions result = mockMvc.perform(
+            delete("/open-chat-rooms/{roomId}/participants/{targetUserId}", ROOM_ID, TARGET_USER_ID)
+                .param("reason", "SPAM"));
+
+        // then
+        result.andExpect(status().isNoContent());
+    }
+
+    // ============================================================
+    // TC-C02: reason 파라미터 누락 → 400 Bad Request
+    // ============================================================
+
+    @Test
+    @DisplayName("400 반환 — TC-C02: reason 파라미터 없이 강퇴 요청 → 400 Bad Request")
+    void should_return_400_when_reason_param_is_missing() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+            delete("/open-chat-rooms/{roomId}/participants/{targetUserId}", ROOM_ID, TARGET_USER_ID));
+
+        // then
+        result.andExpect(status().isBadRequest());
+    }
+
+    // ============================================================
+    // TC-C03: reason에 잘못된 enum 값 → 400 Bad Request
+    // ============================================================
+
+    @Test
+    @DisplayName("400 반환 — TC-C03: reason에 잘못된 enum 값 전달 → 400 Bad Request")
+    void should_return_400_when_reason_has_invalid_enum_value() throws Exception {
+        // when
+        ResultActions result = mockMvc.perform(
+            delete("/open-chat-rooms/{roomId}/participants/{targetUserId}", ROOM_ID, TARGET_USER_ID)
+                .param("reason", "INVALID_REASON"));
+
+        // then
+        result.andExpect(status().isBadRequest());
+    }
+
+    // ============================================================
+    // TC-C04: 비공식 방 단독 방장 자진 퇴장 → 200 OK + roomDeleted=true
+    // ============================================================
+
+    @Test
+    @DisplayName("퇴장 성공 — TC-C04: 비공식 방 단독 방장 자진 퇴장 → 200 OK + roomDeleted=true")
+    void should_return_200_with_room_deleted_true_when_sole_host_leaves_unofficial_room() throws Exception {
+        // given
+        ResponseLeaveOpenChatRoomDto response = ResponseLeaveOpenChatRoomDto.builder().roomDeleted(true).build();
+        given(openChatRoomService.leaveRoom(eq(ROOM_ID), any(), isNull())).willReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(
+            delete("/open-chat-rooms/{roomId}/participants/me", ROOM_ID));
+
+        // then
+        result.andExpect(status().isOk())
+              .andExpect(jsonPath("$.roomDeleted").value(true));
+    }
+
+    // ============================================================
+    // TC-C05: 미인증 요청 → 401 Unauthorized
+    // ============================================================
+
+    @Test
+    @DisplayName("401 반환 — TC-C05: 미인증 상태로 강퇴 요청 → 401 Unauthorized")
+    void should_return_401_when_unauthenticated_kick_request() {
+        // 주의: addFilters=true (Security 필터 활성화) 상태에서 실행해야 합니다.
+        // 현재 @AutoConfigureMockMvc(addFilters = false)와 충돌하므로 별도 테스트 클래스에서 검증 필요.
+        //
+        // when
+        // ResultActions result = mockMvc.perform(
+        //     delete("/open-chat-rooms/{roomId}/participants/{targetUserId}", 1L, 2L)
+        //         .param("reason", "SPAM"));
+        //
+        // then
+        // result.andExpect(status().isUnauthorized());
+        org.assertj.core.api.Assertions.assertThat(true).isTrue();
+    }
+}

--- a/src/test/java/com/example/appcenter_project/domain/openChat/service/OpenChatExitCompletionServiceTest.java
+++ b/src/test/java/com/example/appcenter_project/domain/openChat/service/OpenChatExitCompletionServiceTest.java
@@ -1,0 +1,391 @@
+package com.example.appcenter_project.domain.openChat.service;
+
+import com.example.appcenter_project.domain.openChat.dto.response.ResponseLeaveOpenChatRoomDto;
+import com.example.appcenter_project.domain.openChat.entity.OpenChatParticipant;
+import com.example.appcenter_project.domain.openChat.entity.OpenChatRoom;
+import com.example.appcenter_project.domain.openChat.enums.KickReason;
+import com.example.appcenter_project.domain.openChat.fixture.OpenChatMultiHostFixture;
+import com.example.appcenter_project.domain.openChat.repository.OpenChatMessageRepository;
+import com.example.appcenter_project.domain.openChat.repository.OpenChatParticipantRepository;
+import com.example.appcenter_project.domain.openChat.repository.OpenChatRoomRepository;
+import com.example.appcenter_project.domain.user.entity.User;
+import com.example.appcenter_project.domain.user.enums.Role;
+import com.example.appcenter_project.domain.user.repository.UserRepository;
+import com.example.appcenter_project.global.exception.CustomException;
+import com.example.appcenter_project.global.exception.ErrorCode;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.example.appcenter_project.domain.openChat.fixture.OpenChatMultiHostFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.mock;
+
+/*
+ * BR-659 — 오픈채팅 퇴장 기능 미구현 항목 완성
+ *
+ * 대상 메서드:
+ *   void kickParticipant(Long actorId, Long roomId, Long targetUserId, KickReason reason, Long newHostUserId)
+ *   ResponseLeaveOpenChatRoomDto leaveRoom(Long roomId, Long userId, Long newHostUserId)
+ *
+ * 변경 내용 (기존 테스트와의 차이):
+ *   1. kickParticipant 시그니처에 KickReason reason, Long newHostUserId 추가
+ *   2. ADMIN이 방장을 강퇴할 때 newHostUserId 처리 로직 추가
+ *   3. leaveRoom — 비공식 방에서 단독 방장 자진 퇴장 시 방 하드 삭제
+ *
+ * [kickParticipant — reason 파라미터]
+ * TC-01: 방장이 일반 참여자를 reason=SPAM으로 강퇴 → 204, participant 삭제
+ *
+ * [kickParticipant — ADMIN이 방장 강퇴, 다른 참여자 있음]
+ * TC-02: ADMIN이 방장(A)을 강퇴 + newHostUserId=B → B에게 방장 부여, A 삭제
+ * TC-03: ADMIN이 방장(A)을 강퇴 + newHostUserId 없음 → OPEN_CHAT_NEW_HOST_REQUIRED
+ * TC-04: ADMIN이 방장(A)을 강퇴 + newHostUserId가 방 미참여자 → OPEN_CHAT_PARTICIPANT_NOT_FOUND
+ * TC-05: ADMIN이 방장(A)을 강퇴 + newHostUserId가 이미 방장 → OPEN_CHAT_ALREADY_HOST
+ *
+ * [kickParticipant — ADMIN이 방장 강퇴, 방장 혼자]
+ * TC-06: 방에 방장A만 존재, ADMIN이 강퇴 → participant 삭제 + room 삭제
+ *
+ * [kickParticipant — 방장이 일반 참여자 강퇴 시 newHostUserId 무시]
+ * TC-07: 방장이 일반 참여자 강퇴 시 newHostUserId 전달해도 무시 → participant만 삭제
+ *
+ * [leaveRoom — 비공식 방 마지막 방장 자진 퇴장]
+ * TC-08: 비공식 방에 방장A 혼자 → participant + room 삭제, roomDeleted=true
+ * TC-09: 비공식 방에 방장A + 참여자B, newHostUserId=null → OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE (기존 동작 유지)
+ *
+ * [leaveRoom — 공식 방 마지막 방장 자진 퇴장]
+ * TC-10: 공식 방에 방장A 혼자 → OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE (방 유지)
+ *
+ * [신규 ErrorCode]
+ * OPEN_CHAT_NEW_HOST_REQUIRED(BAD_REQUEST, 22018, "[OpenChat] 방장 강퇴 시 새 방장을 지정해야 합니다.")
+ */
+@ExtendWith(MockitoExtension.class)
+class OpenChatExitCompletionServiceTest {
+
+    @Mock
+    private OpenChatRoomRepository openChatRoomRepository;
+
+    @Mock
+    private OpenChatParticipantRepository openChatParticipantRepository;
+
+    @Mock
+    private OpenChatMessageRepository openChatMessageRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private OpenChatMessageService openChatMessageService;
+
+    @InjectMocks
+    private OpenChatRoomService openChatRoomService;
+
+    // ============================================================
+    // TC-01: kickParticipant — reason 파라미터 포함 정상 강퇴
+    // ============================================================
+
+    @Test
+    @DisplayName("강퇴 성공 — TC-01: 방장이 일반 참여자를 reason=SPAM으로 강퇴하면 participant 삭제됨")
+    void should_delete_participant_when_host_kicks_with_reason() {
+        // given
+        OpenChatRoom room = OpenChatMultiHostFixture.createRoom();
+        OpenChatParticipant targetParticipant = OpenChatParticipant.create(ROOM_ID, PARTICIPANT_USER_ID, false);
+        User hostUser = mock(User.class);
+        given(hostUser.getRole()).willReturn(Role.ROLE_USER);
+        User targetUser = mock(User.class);
+        given(targetUser.getRole()).willReturn(Role.ROLE_USER);
+        given(targetUser.getName()).willReturn("참여자");
+
+        given(openChatRoomRepository.findByIdWithLock(ROOM_ID)).willReturn(Optional.of(room));
+        given(userRepository.findById(HOST_USER_ID)).willReturn(Optional.of(hostUser));
+        given(openChatParticipantRepository.findByRoomIdAndUserId(ROOM_ID, PARTICIPANT_USER_ID)).willReturn(Optional.of(targetParticipant));
+        given(openChatParticipantRepository.existsByRoomIdAndUserIdAndIsHost(ROOM_ID, HOST_USER_ID, true)).willReturn(true);
+        given(userRepository.findById(PARTICIPANT_USER_ID)).willReturn(Optional.of(targetUser));
+
+        // when
+        openChatRoomService.kickParticipant(HOST_USER_ID, ROOM_ID, PARTICIPANT_USER_ID, KickReason.SPAM, null);
+
+        // then
+        then(openChatParticipantRepository).should(times(1)).delete(targetParticipant);
+        then(openChatRoomRepository).should(never()).delete(any());
+    }
+
+    // ============================================================
+    // TC-02: ADMIN이 방장 강퇴 — newHostUserId 유효 → 새 방장 지정 + 대상 삭제
+    // ============================================================
+
+    @Test
+    @DisplayName("강퇴 성공 — TC-02: ADMIN이 방장(A)을 강퇴하면서 newHostUserId=B 지정 → B에게 방장 부여, A participant 삭제")
+    void should_grant_new_host_and_delete_target_when_admin_kicks_host_with_new_host_id() {
+        // given
+        OpenChatRoom room = OpenChatMultiHostFixture.createRoom();
+        OpenChatParticipant hostParticipant = OpenChatParticipant.create(ROOM_ID, HOST_USER_ID, true);
+        OpenChatParticipant participantB = OpenChatParticipant.create(ROOM_ID, PARTICIPANT_USER_ID, false);
+        List<OpenChatParticipant> allParticipants = List.of(hostParticipant, participantB);
+        User adminUser = mock(User.class);
+        given(adminUser.getRole()).willReturn(Role.ROLE_ADMIN);
+        User targetUser = mock(User.class);
+        given(targetUser.getRole()).willReturn(Role.ROLE_USER);
+        given(targetUser.getName()).willReturn("방장A");
+
+        given(openChatRoomRepository.findByIdWithLock(ROOM_ID)).willReturn(Optional.of(room));
+        given(userRepository.findById(ADMIN_USER_ID)).willReturn(Optional.of(adminUser));
+        given(openChatParticipantRepository.findByRoomIdAndUserId(ROOM_ID, HOST_USER_ID)).willReturn(Optional.of(hostParticipant));
+        given(userRepository.findById(HOST_USER_ID)).willReturn(Optional.of(targetUser));
+        given(openChatParticipantRepository.findAllByRoomId(ROOM_ID)).willReturn(allParticipants);
+        given(openChatParticipantRepository.findByRoomIdAndUserId(ROOM_ID, PARTICIPANT_USER_ID)).willReturn(Optional.of(participantB));
+
+        // when
+        openChatRoomService.kickParticipant(ADMIN_USER_ID, ROOM_ID, HOST_USER_ID, KickReason.ABUSE, PARTICIPANT_USER_ID);
+
+        // then
+        assertThat(participantB.isHost()).isTrue();
+        then(openChatParticipantRepository).should(times(1)).delete(hostParticipant);
+        then(openChatRoomRepository).should(never()).delete(any());
+    }
+
+    // ============================================================
+    // TC-03: ADMIN이 방장 강퇴 — newHostUserId 없음, 다른 참여자 있음 → OPEN_CHAT_NEW_HOST_REQUIRED
+    // ============================================================
+
+    @Test
+    @DisplayName("CustomException — TC-03: ADMIN이 방장 강퇴 시 다른 참여자 있는데 newHostUserId 없으면 OPEN_CHAT_NEW_HOST_REQUIRED")
+    void should_throw_when_admin_kicks_host_without_new_host_id_and_others_exist() {
+        // given
+        OpenChatRoom room = OpenChatMultiHostFixture.createRoom();
+        OpenChatParticipant hostParticipant = OpenChatParticipant.create(ROOM_ID, HOST_USER_ID, true);
+        OpenChatParticipant participantB = OpenChatParticipant.create(ROOM_ID, PARTICIPANT_USER_ID, false);
+        List<OpenChatParticipant> allParticipants = List.of(hostParticipant, participantB);
+        User adminUser = mock(User.class);
+        given(adminUser.getRole()).willReturn(Role.ROLE_ADMIN);
+        User targetUser = mock(User.class);
+        given(targetUser.getRole()).willReturn(Role.ROLE_USER);
+
+        given(openChatRoomRepository.findByIdWithLock(ROOM_ID)).willReturn(Optional.of(room));
+        given(userRepository.findById(ADMIN_USER_ID)).willReturn(Optional.of(adminUser));
+        given(openChatParticipantRepository.findByRoomIdAndUserId(ROOM_ID, HOST_USER_ID)).willReturn(Optional.of(hostParticipant));
+        given(userRepository.findById(HOST_USER_ID)).willReturn(Optional.of(targetUser));
+        given(openChatParticipantRepository.findAllByRoomId(ROOM_ID)).willReturn(allParticipants);
+
+        // when
+        ThrowingCallable action = () -> openChatRoomService.kickParticipant(
+            ADMIN_USER_ID, ROOM_ID, HOST_USER_ID, KickReason.ABUSE, null);
+
+        // then
+        assertThatThrownBy(action)
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.OPEN_CHAT_NEW_HOST_REQUIRED);
+    }
+
+    // ============================================================
+    // TC-04: ADMIN이 방장 강퇴 — newHostUserId가 방 미참여자 → OPEN_CHAT_PARTICIPANT_NOT_FOUND
+    // ============================================================
+
+    @Test
+    @DisplayName("CustomException — TC-04: ADMIN이 방장 강퇴 시 newHostUserId가 방 미참여자면 OPEN_CHAT_PARTICIPANT_NOT_FOUND")
+    void should_throw_when_admin_kicks_host_and_new_host_is_not_participant() {
+        // given
+        OpenChatRoom room = OpenChatMultiHostFixture.createRoom();
+        OpenChatParticipant hostParticipant = OpenChatParticipant.create(ROOM_ID, HOST_USER_ID, true);
+        OpenChatParticipant participantB = OpenChatParticipant.create(ROOM_ID, PARTICIPANT_USER_ID, false);
+        List<OpenChatParticipant> allParticipants = List.of(hostParticipant, participantB);
+        User adminUser = mock(User.class);
+        given(adminUser.getRole()).willReturn(Role.ROLE_ADMIN);
+        User targetUser = mock(User.class);
+        given(targetUser.getRole()).willReturn(Role.ROLE_USER);
+
+        given(openChatRoomRepository.findByIdWithLock(ROOM_ID)).willReturn(Optional.of(room));
+        given(userRepository.findById(ADMIN_USER_ID)).willReturn(Optional.of(adminUser));
+        given(openChatParticipantRepository.findByRoomIdAndUserId(ROOM_ID, HOST_USER_ID)).willReturn(Optional.of(hostParticipant));
+        given(userRepository.findById(HOST_USER_ID)).willReturn(Optional.of(targetUser));
+        given(openChatParticipantRepository.findAllByRoomId(ROOM_ID)).willReturn(allParticipants);
+        given(openChatParticipantRepository.findByRoomIdAndUserId(ROOM_ID, NON_PARTICIPANT_USER_ID)).willReturn(Optional.empty());
+
+        // when
+        ThrowingCallable action = () -> openChatRoomService.kickParticipant(
+            ADMIN_USER_ID, ROOM_ID, HOST_USER_ID, KickReason.ABUSE, NON_PARTICIPANT_USER_ID);
+
+        // then
+        assertThatThrownBy(action)
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.OPEN_CHAT_PARTICIPANT_NOT_FOUND);
+    }
+
+    // ============================================================
+    // TC-05: ADMIN이 방장 강퇴 — newHostUserId가 이미 방장 → OPEN_CHAT_ALREADY_HOST
+    // ============================================================
+
+    @Test
+    @DisplayName("CustomException — TC-05: ADMIN이 방장 강퇴 시 newHostUserId가 이미 방장이면 OPEN_CHAT_ALREADY_HOST")
+    void should_throw_when_admin_kicks_host_and_new_host_is_already_host() {
+        // given
+        OpenChatRoom room = OpenChatMultiHostFixture.createRoom();
+        OpenChatParticipant hostParticipant = OpenChatParticipant.create(ROOM_ID, HOST_USER_ID, true);
+        OpenChatParticipant anotherHostParticipant = OpenChatParticipant.create(ROOM_ID, ANOTHER_HOST_USER_ID, true);
+        List<OpenChatParticipant> allParticipants = List.of(hostParticipant, anotherHostParticipant);
+        User adminUser = mock(User.class);
+        given(adminUser.getRole()).willReturn(Role.ROLE_ADMIN);
+        User targetUser = mock(User.class);
+        given(targetUser.getRole()).willReturn(Role.ROLE_USER);
+
+        given(openChatRoomRepository.findByIdWithLock(ROOM_ID)).willReturn(Optional.of(room));
+        given(userRepository.findById(ADMIN_USER_ID)).willReturn(Optional.of(adminUser));
+        given(openChatParticipantRepository.findByRoomIdAndUserId(ROOM_ID, HOST_USER_ID)).willReturn(Optional.of(hostParticipant));
+        given(userRepository.findById(HOST_USER_ID)).willReturn(Optional.of(targetUser));
+        given(openChatParticipantRepository.findAllByRoomId(ROOM_ID)).willReturn(allParticipants);
+        given(openChatParticipantRepository.findByRoomIdAndUserId(ROOM_ID, ANOTHER_HOST_USER_ID)).willReturn(Optional.of(anotherHostParticipant));
+
+        // when
+        ThrowingCallable action = () -> openChatRoomService.kickParticipant(
+            ADMIN_USER_ID, ROOM_ID, HOST_USER_ID, KickReason.ABUSE, ANOTHER_HOST_USER_ID);
+
+        // then
+        assertThatThrownBy(action)
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.OPEN_CHAT_ALREADY_HOST);
+    }
+
+    // ============================================================
+    // TC-06: ADMIN이 방장 강퇴 — 방에 방장 혼자 → participant + room 삭제
+    // ============================================================
+
+    @Test
+    @DisplayName("강퇴 성공 — TC-06: 방에 방장A만 존재할 때 ADMIN이 강퇴하면 participant + room 삭제")
+    void should_delete_participant_and_room_when_admin_kicks_sole_host() {
+        // given
+        OpenChatRoom room = OpenChatMultiHostFixture.createRoom();
+        OpenChatParticipant hostParticipant = OpenChatParticipant.create(ROOM_ID, HOST_USER_ID, true);
+        List<OpenChatParticipant> allParticipants = List.of(hostParticipant);
+        User adminUser = mock(User.class);
+        given(adminUser.getRole()).willReturn(Role.ROLE_ADMIN);
+        User targetUser = mock(User.class);
+        given(targetUser.getRole()).willReturn(Role.ROLE_USER);
+
+        given(openChatRoomRepository.findByIdWithLock(ROOM_ID)).willReturn(Optional.of(room));
+        given(userRepository.findById(ADMIN_USER_ID)).willReturn(Optional.of(adminUser));
+        given(openChatParticipantRepository.findByRoomIdAndUserId(ROOM_ID, HOST_USER_ID)).willReturn(Optional.of(hostParticipant));
+        given(userRepository.findById(HOST_USER_ID)).willReturn(Optional.of(targetUser));
+        given(openChatParticipantRepository.findAllByRoomId(ROOM_ID)).willReturn(allParticipants);
+
+        // when
+        openChatRoomService.kickParticipant(ADMIN_USER_ID, ROOM_ID, HOST_USER_ID, KickReason.OTHER, null);
+
+        // then
+        then(openChatParticipantRepository).should(times(1)).delete(hostParticipant);
+        then(openChatRoomRepository).should(times(1)).delete(room);
+    }
+
+    // ============================================================
+    // TC-07: 방장이 일반 참여자 강퇴 시 newHostUserId 무시
+    // ============================================================
+
+    @Test
+    @DisplayName("강퇴 성공 — TC-07: 방장이 일반 참여자 강퇴 시 newHostUserId 전달해도 participant만 삭제, 방 유지")
+    void should_ignore_new_host_user_id_when_host_kicks_normal_participant() {
+        // given
+        OpenChatRoom room = OpenChatMultiHostFixture.createRoom();
+        OpenChatParticipant targetParticipant = OpenChatParticipant.create(ROOM_ID, PARTICIPANT_USER_ID, false);
+        User hostUser = mock(User.class);
+        given(hostUser.getRole()).willReturn(Role.ROLE_USER);
+        User targetUser = mock(User.class);
+        given(targetUser.getRole()).willReturn(Role.ROLE_USER);
+        given(targetUser.getName()).willReturn("참여자");
+
+        given(openChatRoomRepository.findByIdWithLock(ROOM_ID)).willReturn(Optional.of(room));
+        given(userRepository.findById(HOST_USER_ID)).willReturn(Optional.of(hostUser));
+        given(openChatParticipantRepository.findByRoomIdAndUserId(ROOM_ID, PARTICIPANT_USER_ID)).willReturn(Optional.of(targetParticipant));
+        given(openChatParticipantRepository.existsByRoomIdAndUserIdAndIsHost(ROOM_ID, HOST_USER_ID, true)).willReturn(true);
+        given(userRepository.findById(PARTICIPANT_USER_ID)).willReturn(Optional.of(targetUser));
+
+        // when
+        openChatRoomService.kickParticipant(HOST_USER_ID, ROOM_ID, PARTICIPANT_USER_ID, KickReason.SPAM, ANOTHER_HOST_USER_ID);
+
+        // then
+        then(openChatParticipantRepository).should(times(1)).delete(targetParticipant);
+        then(openChatRoomRepository).should(never()).delete(any());
+    }
+
+    // ============================================================
+    // TC-08: leaveRoom — 비공식 방 단독 방장 자진 퇴장 → 방 하드 삭제
+    // ============================================================
+
+    @Test
+    @DisplayName("퇴장 성공 — TC-08: 비공식 방에 방장A 혼자일 때 자진 퇴장하면 participant + room 삭제, roomDeleted=true")
+    void should_delete_participant_and_room_when_sole_host_leaves_unofficial_room() {
+        // given
+        OpenChatRoom unofficialRoom = OpenChatMultiHostFixture.createRoom();
+        OpenChatParticipant soleHost = OpenChatParticipant.create(ROOM_ID, HOST_USER_ID, true);
+        List<OpenChatParticipant> lockedList = List.of(soleHost);
+
+        given(openChatParticipantRepository.findAllByRoomIdWithLock(ROOM_ID)).willReturn(lockedList);
+        given(openChatRoomRepository.findByIdWithLock(ROOM_ID)).willReturn(Optional.of(unofficialRoom));
+
+        // when
+        ResponseLeaveOpenChatRoomDto result = openChatRoomService.leaveRoom(ROOM_ID, HOST_USER_ID, null);
+
+        // then
+        assertThat(result.isRoomDeleted()).isTrue();
+        then(openChatParticipantRepository).should(times(1)).deleteAll(lockedList);
+        then(openChatRoomRepository).should(times(1)).delete(unofficialRoom);
+    }
+
+    // ============================================================
+    // TC-09: leaveRoom — 비공식 방 방장 + 다른 참여자 있음, newHostUserId=null → 기존 예외 유지
+    // ============================================================
+
+    @Test
+    @DisplayName("CustomException — TC-09: 비공식 방에 방장A + 참여자B인데 newHostUserId=null로 자진 퇴장 시도 → OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE")
+    void should_throw_when_sole_host_leaves_unofficial_room_with_other_participants() {
+        // given
+        OpenChatParticipant soleHost = OpenChatParticipant.create(ROOM_ID, HOST_USER_ID, true);
+        OpenChatParticipant participantB = OpenChatParticipant.create(ROOM_ID, PARTICIPANT_USER_ID, false);
+        List<OpenChatParticipant> lockedList = List.of(soleHost, participantB);
+
+        given(openChatParticipantRepository.findAllByRoomIdWithLock(ROOM_ID)).willReturn(lockedList);
+
+        // when
+        ThrowingCallable action = () -> openChatRoomService.leaveRoom(ROOM_ID, HOST_USER_ID, null);
+
+        // then
+        assertThatThrownBy(action)
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE);
+    }
+
+    // ============================================================
+    // TC-10: leaveRoom — 공식 방 단독 방장 자진 퇴장 → OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE
+    // ============================================================
+
+    @Test
+    @DisplayName("CustomException — TC-10: 공식 방에 방장A 혼자일 때 자진 퇴장 시도 → OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE (방 유지)")
+    void should_throw_when_sole_host_leaves_official_room() {
+        // given
+        OpenChatRoom officialRoom = OpenChatMultiHostFixture.createOfficialRoom();
+        OpenChatParticipant soleHost = OpenChatParticipant.create(ROOM_ID, ADMIN_USER_ID, true);
+        List<OpenChatParticipant> lockedList = List.of(soleHost);
+
+        given(openChatParticipantRepository.findAllByRoomIdWithLock(ROOM_ID)).willReturn(lockedList);
+        given(openChatRoomRepository.findByIdWithLock(ROOM_ID)).willReturn(Optional.of(officialRoom));
+
+        // when
+        ThrowingCallable action = () -> openChatRoomService.leaveRoom(ROOM_ID, ADMIN_USER_ID, null);
+
+        // then
+        assertThatThrownBy(action)
+            .isInstanceOf(CustomException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.OPEN_CHAT_SOLE_HOST_CANNOT_LEAVE);
+        then(openChatRoomRepository).should(never()).delete(any());
+    }
+}


### PR DESCRIPTION
## Summary

- `kickParticipant` 엔드포인트에 `reason` (KickReason enum) 필수 파라미터 및 `newHostUserId` 옵션 파라미터 추가
- ADMIN이 방장을 강퇴할 때 다른 참여자가 있으면 새 방장 지정 필수 (`OPEN_CHAT_NEW_HOST_REQUIRED` 22018 추가)
- 비공식 방 단독 방장이 혼자 남았을 때 자진 퇴장 시 방 하드 삭제 후 `roomDeleted: true` 반환
- `GlobalExceptionHandler`에 `MissingServletRequestParameterException` / `MethodArgumentTypeMismatchException` 핸들러 추가 (기존 500 → 400)
- `kickParticipant` 내 중복 `findByRoomIdAndUserId` 쿼리 제거
- `leaveRoom` / `kickParticipant` 전 경로에 `log.info` 운영 로그 추가
- `chat-test.html`: 강퇴 사유 선택 모달 추가, 나가기 로직에서 비공식 방 단독 방장 케이스 처리

## Test plan

- [x] `OpenChatExitCompletionServiceTest` — TC-01~10 전체 통과
- [x] `OpenChatExitCompletionControllerTest` — TC-C01~C04 활성화 및 통과 (`@WebMvcTest`)
- [x] `./gradlew test` 전체 빌드 통과
- [ ] 방장이 일반 참여자 강퇴 시 reason=SPAM 파라미터 포함 요청 → 204 확인
- [x] reason 파라미터 누락 시 → 400 확인
- [x] ADMIN이 방장 강퇴 시 newHostUserId 없으면 → 400 (22018) 확인
- [x] 비공식 방 단독 방장 자진 퇴장 → roomDeleted: true + 방 삭제 확인
- [x] chat-test.html 강퇴 모달 UI 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)