### PR TITLE
feat: 알림 읽음 처리 구현 (BR-680)

### DIFF
--- a/specs/BR-680-notification-read/api-spec.md
+++ b/specs/BR-680-notification-read/api-spec.md
@@ -1,0 +1,102 @@
+# 알림 읽음 처리 API 명세서 (BR-680)
+
+> Base URL: `{server-host}`  
+> Controller: `NotificationController` (`/notifications`)
+
+---
+
+## 알림 읽음 처리
+
+| 항목 | 내용 |
+|------|------|
+| **메서드** | `PATCH` |
+| **경로** | `/notifications/read` |
+| **인증** | Bearer Token (JWT) 필수 |
+| **설명** | 공지사항 또는 채팅방 진입 시 해당 알림의 읽음 상태를 서버에 동기화한다. NOTICE 타입은 `UserNotification.isRead`를, CHAT 타입은 `OpenChatParticipant.lastReadMessageId`를 업데이트한다. |
+
+### Request
+
+#### Request Body
+
+Content-Type: `application/json`
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `type` | `String` | ✅ | 알림 타입. `"NOTICE"` 또는 `"CHAT"` 만 허용 (대소문자 구분) |
+| `targetId` | `String` | ✅ | 읽음 처리할 대상의 PK. NOTICE이면 공지사항 ID, CHAT이면 채팅방 ID |
+
+```json
+// 공지사항 진입 시
+{
+  "type": "NOTICE",
+  "targetId": "5678"
+}
+
+// 채팅방 진입 시
+{
+  "type": "CHAT",
+  "targetId": "1234"
+}
+```
+
+### Response
+
+#### 성공 응답 — `200 OK`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `success` | `boolean` | 항상 `true` |
+| `message` | `String` | 고정 문자열 |
+
+```json
+{
+  "success": true,
+  "message": "성공적으로 읽음 처리되었습니다."
+}
+```
+
+> **멱등성**: NOTICE 타입에서 대상 `UserNotification`이 없거나 이미 읽음 상태여도 200 OK를 반환한다.  
+> **CHAT 타입**: 채팅방에 메시지가 없으면 `lastReadMessageId`를 변경하지 않고 200 OK를 반환한다.
+
+#### 에러 응답
+
+에러 응답 공통 형식:
+
+```json
+{
+  "code": 5001,
+  "name": "VALIDATION_FAILED",
+  "message": "[Validation] Request에서 요청한 값이 올바르지 않습니다."
+}
+```
+
+| 상태 코드 | ErrorCode | code | 발생 조건 |
+|-----------|-----------|------|-----------|
+| `400 Bad Request` | `VALIDATION_FAILED` | 5001 | `type`이 `null`이거나 `NOTICE`/`CHAT` 이외의 값, 또는 `targetId`가 비어있거나 숫자로 파싱 불가 |
+| `401 Unauthorized` | `JWT_ENTRY_POINT` | 1007 | JWT 토큰 없음 또는 유효하지 않음 |
+| `403 Forbidden` | `OPEN_CHAT_NOT_PARTICIPANT` | 22005 | CHAT 타입 요청 시 해당 채팅방의 참여자가 아님 |
+
+```json
+// 401 예시
+{
+  "code": 1007,
+  "name": "JWT_ENTRY_POINT",
+  "message": "[Jwt] 인증되지 않은 사용자입니다."
+}
+
+// 403 예시 (CHAT 타입, 비참여자)
+{
+  "code": 22005,
+  "name": "OPEN_CHAT_NOT_PARTICIPANT",
+  "message": "[OpenChat] 채팅 내역 조회 권한이 없습니다."
+}
+```
+
+---
+
+## 추론 항목
+
+> 아래 항목은 코드에서 명시적으로 확인되지 않아 기존 코드 패턴 및 명세로 추론했습니다.
+
+- **타입 유효성 검증**: `FcmRoutingType` Jackson 역직렬화 시 잘못된 값을 400으로 반환하려면, 구현 시 `HttpMessageNotReadableException` 핸들러를 `GlobalExceptionHandler`에 추가하거나 DTO에서 String으로 받아 서비스에서 명시 검증하는 방식을 선택해야 한다.
+- **OPEN_CHAT_NOT_PARTICIPANT HTTP 상태**: requirement.md에는 404로 기술되어 있으나 `ErrorCode.java` 기준 실제 HTTP 상태는 `403 FORBIDDEN`이다. 명세 오기재이므로 코드 기준인 403으로 작성했다.

--- a/specs/BR-680-notification-read/design.md
+++ b/specs/BR-680-notification-read/design.md
@@ -1,0 +1,119 @@
+## 엔티티 / 값 객체
+
+신규 엔티티 없음. 기존 엔티티의 필드만 변경한다.
+
+| 엔티티 | 변경 필드 | 변경 내용 |
+|---|---|---|
+| `UserNotification` | `isRead` | NOTICE 타입 요청 시 `false → true` (기존 `changeReadStatus()` 활용) |
+| `OpenChatParticipant` | `lastReadMessageId` | CHAT 타입 요청 시 해당 방 최신 메시지 ID로 업데이트 (기존 `updateLastReadMessageId()` 활용) |
+
+---
+
+## 애그리거트 경계
+
+- `UserNotification`은 `Notification`을 `@ManyToOne(LAZY)`로 참조한다. 조회 시 `notification.boardId`와 `notification.apiType`에 접근하므로 JOIN FETCH 또는 QueryDSL join이 필요하다.
+- `OpenChatParticipant`는 독립 애그리거트 루트이며 `roomId`, `userId`로 식별된다. `OpenChatMessage`는 별도 조회한다.
+
+---
+
+## 연관관계
+
+변경 없음. 기존 연관관계를 그대로 사용한다.
+
+---
+
+## DB 스키마 변경
+
+없음.
+
+---
+
+## 도메인 계층 구조
+
+### 신규 생성 클래스
+
+```
+domain/notification/
+├── controller/
+│   (수정) NotificationController.java        — PATCH /notifications/read 엔드포인트 추가
+│   (수정) NotificationApiSpecification.java  — markAsRead 메서드 시그니처 추가
+├── service/
+│   (신규) NotificationReadService.java       — NOTICE/CHAT 분기 처리 서비스
+├── repository/
+│   (수정) UserNotificationQuerydslRepository.java  — findByUserIdAndBoardIdAndApiType 추가
+│   (수정) UserNotificationRepositoryImpl.java      — QueryDSL 구현 추가
+└── dto/
+    ├── request/
+    │   (신규) RequestNotificationReadDto.java — type(FcmRoutingType), targetId(String)
+    └── response/
+        (신규) ResponseNotificationReadDto.java — success(boolean), message(String)
+
+domain/openChat/
+└── service/
+    (수정) OpenChatMessageService.java         — markChatRoomAsRead(roomId, userId) 추가
+```
+
+### 클래스별 역할
+
+**`RequestNotificationReadDto`**
+```
+- type: FcmRoutingType  (@NotNull, Jackson이 역직렬화 시 잘못된 값은 400 자동 처리)
+- targetId: String      (@NotBlank)
+```
+
+**`ResponseNotificationReadDto`**
+```
+- success: boolean  (항상 true)
+- message: String   ("성공적으로 읽음 처리되었습니다." 고정)
+```
+
+**`NotificationReadService`**
+```
+의존:
+  - UserNotificationQuerydslRepository (NOTICE 조회)
+  - OpenChatMessageService            (CHAT 처리 위임, 도메인 간 service 호출)
+
+메서드:
+  markAsRead(Long userId, FcmRoutingType type, Long targetId): ResponseNotificationReadDto
+  - NOTICE → findByUserIdAndBoardIdAndApiType 조회 후 isRead = true
+  - CHAT   → openChatMessageService.markChatRoomAsRead(targetId, userId)
+```
+
+**`UserNotificationQuerydslRepository` 추가 메서드**
+```
+List<UserNotification> findByUserIdAndBoardIdAndApiType(Long userId, Long boardId, ApiType apiType)
+  - JOIN notification ON userNotification.notification = notification
+  - WHERE user.id = userId AND notification.boardId = boardId AND notification.apiType = apiType
+```
+
+**`OpenChatMessageService` 추가 메서드**
+```
+markChatRoomAsRead(Long roomId, Long userId): void
+  1. findByRoomIdAndUserId → 없으면 OPEN_CHAT_NOT_PARTICIPANT 예외
+  2. findLatestMessageIdByRoomId → Optional<Long>
+  3. 최신 메시지 있으면 updateLastReadMessageId(roomId, userId, latestId)
+```
+
+---
+
+## 흐름 요약
+
+```
+NotificationController.markAsRead(userId, dto)
+  └─ NotificationReadService.markAsRead(userId, type, targetId)
+       ├─ [NOTICE] UserNotificationQuerydslRepository.findByUserIdAndBoardIdAndApiType()
+       │            → forEach: userNotification.changeReadStatus(true)
+       └─ [CHAT]   OpenChatMessageService.markChatRoomAsRead(targetId, userId)
+                    ├─ OpenChatParticipantRepository.findByRoomIdAndUserId() [없으면 예외]
+                    └─ OpenChatMessageQuerydslRepository.findLatestMessageIdByRoomId()
+                         → OpenChatParticipantRepository.updateLastReadMessageId()
+```
+
+---
+
+## 비목표
+
+- `FcmOutbox` 상태 변경: 이번 범위 외
+- 배지 카운트 재계산: 이번 범위 외
+- CHAT 요청 시 `UserNotification.isRead` 변경: 명세상 비목표
+- `OpenChatMessage` 도메인 신규 엔티티·테이블: 기존 코드 재사용만

--- a/specs/BR-680-notification-read/requirement.md
+++ b/specs/BR-680-notification-read/requirement.md
@@ -1,0 +1,125 @@
+## 기능 요약
+
+사용자가 공지사항 상세 화면 또는 채팅방 상세 화면에 진입했을 때 클라이언트(네이티브)가 호출하는 읽음 처리 API. `type`에 따라 공지 알림 읽음 상태(`UserNotification.isRead`) 또는 채팅방 미읽음 카운트(`OpenChatParticipant.lastReadMessageId`)를 업데이트한다.
+
+---
+
+## 동작 명세
+
+### 엔드포인트
+
+```
+PATCH /notifications/read
+Content-Type: application/json
+Authorization: Bearer {JWT}
+```
+
+### 요청
+
+```json
+// NOTICE 타입
+{ "type": "NOTICE", "targetId": "5678" }
+
+// CHAT 타입
+{ "type": "CHAT", "targetId": "1234" }
+```
+
+- `type`: `"NOTICE"` 또는 `"CHAT"` (FcmRoutingType 값과 동일)
+- `targetId`: 공지사항 PK 또는 채팅방 PK (String → 내부에서 Long으로 파싱)
+
+### 응답
+
+```json
+// 200 OK
+{ "success": true, "message": "성공적으로 읽음 처리되었습니다." }
+```
+
+### 처리 흐름
+
+**NOTICE 타입**
+
+1. JWT에서 인증된 userId 추출
+2. `UserNotification` 중 `user.id = userId` AND `notification.boardId = targetId(Long)` AND `notification.apiType = ANNOUNCEMENT`인 레코드 조회
+3. 해당 레코드의 `isRead = true`로 변경 (레코드가 없으면 아무것도 하지 않고 성공 반환)
+4. 200 OK 반환
+
+**CHAT 타입**
+
+1. JWT에서 인증된 userId 추출
+2. `OpenChatParticipant` 조회 (`roomId = targetId`, `userId = userId`) — 미참여면 예외
+3. 해당 방의 최신 메시지 ID 조회 (`findLatestMessageIdByRoomId`)
+4. 최신 메시지가 있으면 `OpenChatParticipant.lastReadMessageId`를 해당 ID로 업데이트
+5. 방에 메시지가 없으면 업데이트 없이 성공 반환
+6. 200 OK 반환
+
+---
+
+## 도메인 데이터
+
+### NOTICE 처리 대상
+
+| 엔티티 | 필드 | 비고 |
+|---|---|---|
+| `Notification` | `boardId` | 공지사항 PK (announcementId) |
+| `Notification` | `apiType` | `ANNOUNCEMENT` 고정 |
+| `UserNotification` | `isRead` | `false` → `true` |
+
+### CHAT 처리 대상
+
+| 엔티티 | 필드 | 비고 |
+|---|---|---|
+| `OpenChatParticipant` | `lastReadMessageId` | null 또는 이전 값 → 최신 메시지 ID |
+
+---
+
+## 비즈니스 규칙 / 제약
+
+- 인증 필수: JWT에서 userId를 추출한다. 비인증 요청은 Spring Security에서 차단.
+- `type`은 대소문자 구분 없이 `NOTICE` / `CHAT`만 허용. 그 외 값은 400 반환.
+- `targetId`는 양수 정수로 파싱 가능해야 한다. 파싱 실패 시 400 반환.
+- NOTICE: 대상 `UserNotification`이 없어도 에러 없이 성공 처리 (멱등성).
+- CHAT: 해당 방의 참여자가 아닌 경우 예외 (`OPEN_CHAT_NOT_PARTICIPANT`).
+- 배지 카운트 재계산은 이번 범위에서 구현하지 않는다 (Non-goal).
+
+---
+
+## 예외 · 경계 상황
+
+| 상황 | 기대 동작 |
+|---|---|
+| 잘못된 `type` 값 (예: `"ROOMMATE"`) | 400 BAD_REQUEST |
+| `targetId`가 숫자가 아닌 문자열 | 400 BAD_REQUEST |
+| NOTICE: 대상 UserNotification 없음 | 200 OK (아무것도 하지 않음) |
+| CHAT: 해당 방 참여자 아님 | 404 (OPEN_CHAT_NOT_PARTICIPANT) |
+| CHAT: 방에 메시지가 없음 | 200 OK (lastReadMessageId 변경 없음) |
+
+---
+
+## 비목표 (Non-goals)
+
+- 배지 카운트(Badge Count) 재계산 및 FCM 발송
+- CHAT 타입 요청 시 `UserNotification` 레코드 읽음 처리 (lastReadMessageId 업데이트만)
+- `FcmOutbox` 상태 변경
+- 공지사항 상세 조회 API (별도 도메인)
+- 채팅방 메시지 조회 API (기존 WebSocket/REST 흐름 유지)
+
+---
+
+## 수용 기준 (Acceptance Criteria)
+
+### NOTICE 타입
+
+- **AC-1** Given 인증된 사용자, When `type=NOTICE, targetId=5` 요청, Then 해당 사용자의 `UserNotification` 중 `boardId=5 AND apiType=ANNOUNCEMENT`인 레코드의 `isRead`가 `true`로 변경된다.
+- **AC-2** Given 인증된 사용자, When `type=NOTICE, targetId=999` 요청(해당 알림 없음), Then 예외 없이 200 OK 반환.
+- **AC-3** Given `type=NOTICE`이지만 `targetId`가 숫자가 아닌 경우, Then 400 반환.
+
+### CHAT 타입
+
+- **AC-4** Given 인증된 사용자이고 채팅방 참여자, When `type=CHAT, targetId=1` 요청, Then `OpenChatParticipant.lastReadMessageId`가 해당 방의 최신 메시지 ID로 업데이트된다.
+- **AC-5** Given 인증된 사용자이고 채팅방 참여자, 방에 메시지가 없을 때, When `type=CHAT, targetId=1` 요청, Then 200 OK 반환 (lastReadMessageId 변경 없음).
+- **AC-6** Given 인증된 사용자이지만 해당 채팅방 참여자가 아님, When `type=CHAT, targetId=1` 요청, Then 404 (OPEN_CHAT_NOT_PARTICIPANT) 반환.
+
+### 공통
+
+- **AC-7** Given 잘못된 `type` 값, When 요청, Then 400 BAD_REQUEST 반환.
+- **AC-8** Given 비인증 요청, When 요청, Then 401 반환.

--- a/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationApiSpecification.java
@@ -1,8 +1,10 @@
 package com.example.appcenter_project.domain.notification.controller;
 
 import com.example.appcenter_project.domain.notification.dto.request.RequestNotificationDto;
+import com.example.appcenter_project.domain.notification.dto.request.RequestNotificationReadDto;
 import com.example.appcenter_project.domain.notification.dto.request.RequestSendDirectNotificationDto;
 import com.example.appcenter_project.domain.notification.dto.response.ResponseNotificationDto;
+import com.example.appcenter_project.domain.notification.dto.response.ResponseNotificationReadDto;
 import com.example.appcenter_project.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,6 +23,19 @@ import java.util.List;
 
 @Tag(name = "Notification API", description = "알림 관련 API")
 public interface NotificationApiSpecification {
+
+    @Operation(
+            summary = "알림 읽음 처리",
+            description = "공지사항 또는 채팅방 진입 시 해당 알림의 읽음 상태를 서버에 동기화합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "읽음 처리 성공"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                    @ApiResponse(responseCode = "403", description = "채팅방 참여자가 아님")
+            }
+    )
+    ResponseEntity<ResponseNotificationReadDto> markAsRead(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody RequestNotificationReadDto dto);
 
     @Operation(
             summary = "알림 생성",

--- a/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/controller/NotificationController.java
@@ -2,10 +2,14 @@ package com.example.appcenter_project.domain.notification.controller;
 
 import com.example.appcenter_project.common.metrics.annotation.TrackApi;
 import com.example.appcenter_project.domain.notification.dto.request.RequestNotificationDto;
+import com.example.appcenter_project.domain.notification.dto.request.RequestNotificationReadDto;
 import com.example.appcenter_project.domain.notification.dto.request.RequestSendDirectNotificationDto;
 import com.example.appcenter_project.domain.notification.dto.response.ResponseNotificationDto;
+import com.example.appcenter_project.domain.notification.dto.response.ResponseNotificationReadDto;
 import com.example.appcenter_project.global.security.CustomUserDetails;
+import com.example.appcenter_project.domain.notification.service.NotificationReadService;
 import com.example.appcenter_project.domain.notification.service.NotificationService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,6 +25,16 @@ import static org.springframework.http.HttpStatus.*;
 public class NotificationController implements NotificationApiSpecification {
 
     private final NotificationService notificationService;
+    private final NotificationReadService notificationReadService;
+
+    @PatchMapping("/read")
+    public ResponseEntity<ResponseNotificationReadDto> markAsRead(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody @Valid RequestNotificationReadDto dto) {
+        Long targetId = dto.getTargetIdAsLong();
+        return ResponseEntity.status(OK).body(
+                notificationReadService.markAsRead(user != null ? user.getId() : null, dto.getType(), targetId));
+    }
 
     @PostMapping
     public ResponseEntity<Void> saveNotification(@RequestBody RequestNotificationDto requestNotificationDto) {

--- a/src/main/java/com/example/appcenter_project/domain/notification/dto/request/RequestNotificationReadDto.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/dto/request/RequestNotificationReadDto.java
@@ -1,0 +1,36 @@
+package com.example.appcenter_project.domain.notification.dto.request;
+
+import com.example.appcenter_project.domain.fcm.enums.FcmRoutingType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RequestNotificationReadDto {
+
+    @NotNull
+    private FcmRoutingType type;
+
+    @NotBlank
+    private String targetId;
+
+    public RequestNotificationReadDto(FcmRoutingType type, String targetId) {
+        this.type = type;
+        this.targetId = targetId;
+    }
+
+    public Long getTargetIdAsLong() {
+        try {
+            long value = Long.parseLong(targetId);
+            if (value <= 0) {
+                throw new NumberFormatException();
+            }
+            return value;
+        } catch (NumberFormatException e) {
+            throw new com.example.appcenter_project.global.exception.CustomException(
+                    com.example.appcenter_project.global.exception.ErrorCode.VALIDATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/example/appcenter_project/domain/notification/dto/response/ResponseNotificationReadDto.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/dto/response/ResponseNotificationReadDto.java
@@ -1,0 +1,19 @@
+package com.example.appcenter_project.domain.notification.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResponseNotificationReadDto {
+
+    private boolean success;
+    private String message;
+
+    public static ResponseNotificationReadDto success() {
+        return ResponseNotificationReadDto.builder()
+                .success(true)
+                .message("성공적으로 읽음 처리되었습니다.")
+                .build();
+    }
+}

--- a/src/main/java/com/example/appcenter_project/domain/notification/repository/UserNotificationQuerydslRepository.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/repository/UserNotificationQuerydslRepository.java
@@ -1,10 +1,12 @@
 package com.example.appcenter_project.domain.notification.repository;
 
 import com.example.appcenter_project.domain.notification.entity.UserNotification;
+import com.example.appcenter_project.shared.enums.ApiType;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface UserNotificationQuerydslRepository {
     List<UserNotification> findAllWithFilters(Long userId, Long lastId, Pageable pageable);
+    List<UserNotification> findByUserIdAndBoardIdAndApiType(Long userId, Long boardId, ApiType apiType);
 }

--- a/src/main/java/com/example/appcenter_project/domain/notification/repository/UserNotificationRepositoryImpl.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/repository/UserNotificationRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.example.appcenter_project.domain.notification.repository;
 
 import com.example.appcenter_project.domain.notification.entity.UserNotification;
+import com.example.appcenter_project.shared.enums.ApiType;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
@@ -36,6 +37,19 @@ public class UserNotificationRepositoryImpl implements UserNotificationQuerydslR
                 )
                 .orderBy(userNotification.id.desc())
                 .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    @Override
+    public List<UserNotification> findByUserIdAndBoardIdAndApiType(Long userId, Long boardId, ApiType apiType) {
+        return queryFactory
+                .selectFrom(userNotification)
+                .join(userNotification.notification, notification).fetchJoin()
+                .where(
+                        userNotification.user.id.eq(userId),
+                        notification.boardId.eq(boardId),
+                        notification.apiType.eq(apiType)
+                )
                 .fetch();
     }
 

--- a/src/main/java/com/example/appcenter_project/domain/notification/service/NotificationReadService.java
+++ b/src/main/java/com/example/appcenter_project/domain/notification/service/NotificationReadService.java
@@ -1,0 +1,33 @@
+package com.example.appcenter_project.domain.notification.service;
+
+import com.example.appcenter_project.domain.fcm.enums.FcmRoutingType;
+import com.example.appcenter_project.domain.notification.dto.response.ResponseNotificationReadDto;
+import com.example.appcenter_project.domain.notification.entity.UserNotification;
+import com.example.appcenter_project.domain.notification.repository.UserNotificationQuerydslRepository;
+import com.example.appcenter_project.domain.openChat.service.OpenChatMessageService;
+import com.example.appcenter_project.shared.enums.ApiType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationReadService {
+
+    private final UserNotificationQuerydslRepository userNotificationQuerydslRepository;
+    private final OpenChatMessageService openChatMessageService;
+
+    @Transactional
+    public ResponseNotificationReadDto markAsRead(Long userId, FcmRoutingType type, Long targetId) {
+        if (type == FcmRoutingType.NOTICE) {
+            List<UserNotification> userNotifications =
+                    userNotificationQuerydslRepository.findByUserIdAndBoardIdAndApiType(userId, targetId, ApiType.ANNOUNCEMENT);
+            userNotifications.forEach(un -> un.changeReadStatus(true));
+        } else {
+            openChatMessageService.markChatRoomAsRead(targetId, userId);
+        }
+        return ResponseNotificationReadDto.success();
+    }
+}

--- a/src/main/java/com/example/appcenter_project/domain/openChat/service/OpenChatMessageService.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/service/OpenChatMessageService.java
@@ -261,6 +261,14 @@ public class OpenChatMessageService {
                 .build();
     }
 
+    public void markChatRoomAsRead(Long roomId, Long userId) {
+        openChatParticipantRepository.findByRoomIdAndUserId(roomId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.OPEN_CHAT_NOT_PARTICIPANT));
+
+        openChatMessageRepository.findLatestMessageIdByRoomId(roomId).ifPresent(latestId ->
+                openChatParticipantRepository.updateLastReadMessageId(roomId, userId, latestId));
+    }
+
     public int calculateUnreadCount(Long roomId, Long messageId) {
         long total = openChatParticipantRepository.countByRoomId(roomId);
         long readCount = openChatParticipantRepository.countReadByRoomIdAndMessageId(roomId, messageId);

--- a/src/main/java/com/example/appcenter_project/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/appcenter_project/global/config/SecurityConfig.java
@@ -136,6 +136,8 @@ public class SecurityConfig {
                         /** 알림 **/
                         // 특정 유저 1:1 직접 알림 전송(ADMIN 전용)
                         .requestMatchers(POST, "/notifications/admin/direct").hasRole("ADMIN")
+                        // 알림 읽음 처리(로그인한 사용자)
+                        .requestMatchers(PATCH, "/notifications/read").authenticated()
                         // 알림 조회(로그인한 사용자)
                         .requestMatchers(GET, "/notifications/**").permitAll()
                         // 알림 등록, 수정, 삭제(관리자)

--- a/src/main/java/com/example/appcenter_project/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/appcenter_project/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -61,6 +62,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseEntity> handleMissingPart(MissingServletRequestPartException ex) {
         log.warn("MissingServletRequestPartException 발생: {}", ex.getMessage());
 
+        return ErrorResponseEntity.toResponseEntity(ErrorCode.VALIDATION_FAILED);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponseEntity> handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
+        log.warn("HttpMessageNotReadableException 발생: {}", ex.getMessage());
         return ErrorResponseEntity.toResponseEntity(ErrorCode.VALIDATION_FAILED);
     }
 

--- a/src/test/java/com/example/appcenter_project/domain/notification/controller/NotificationReadControllerTest.java
+++ b/src/test/java/com/example/appcenter_project/domain/notification/controller/NotificationReadControllerTest.java
@@ -1,0 +1,239 @@
+package com.example.appcenter_project.domain.notification.controller;
+
+import com.example.appcenter_project.domain.fcm.enums.FcmRoutingType;
+import com.example.appcenter_project.domain.notification.dto.request.RequestNotificationReadDto;
+import com.example.appcenter_project.domain.notification.dto.response.ResponseNotificationReadDto;
+import com.example.appcenter_project.domain.notification.service.NotificationReadService;
+import com.example.appcenter_project.domain.notification.service.NotificationService;
+import com.example.appcenter_project.global.exception.CustomException;
+import com.example.appcenter_project.global.exception.ErrorCode;
+import com.example.appcenter_project.global.exception.SlackErrorNotifier;
+import com.example.appcenter_project.global.security.CustomUserDetails;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NotificationController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class NotificationReadControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @MockBean
+    private NotificationReadService notificationReadService;
+
+    @MockBean
+    private SlackErrorNotifier slackErrorNotifier;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    private CustomUserDetails mockUser;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = new CustomUserDetails();
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(mockUser, null, mockUser.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // =========================================================================
+    // AC-1·4: 200 OK — 정상 요청
+    // =========================================================================
+
+    @Test
+    @DisplayName("AC-1: 200 반환 — NOTICE 타입 정상 요청")
+    void should_return_200_when_NOTICE_type_valid() throws Exception {
+        RequestNotificationReadDto request = new RequestNotificationReadDto(FcmRoutingType.NOTICE, "5678");
+        ResponseNotificationReadDto response = ResponseNotificationReadDto.success();
+
+        given(notificationReadService.markAsRead(nullable(Long.class), eq(FcmRoutingType.NOTICE), eq(5678L)))
+                .willReturn(response);
+
+        ResultActions result = mockMvc.perform(
+                patch("/notifications/read")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpect(status().isOk())
+              .andExpect(jsonPath("$.success").value(true))
+              .andExpect(jsonPath("$.message").value("성공적으로 읽음 처리되었습니다."));
+    }
+
+    @Test
+    @DisplayName("AC-4: 200 반환 — CHAT 타입 정상 요청")
+    void should_return_200_when_CHAT_type_valid() throws Exception {
+        RequestNotificationReadDto request = new RequestNotificationReadDto(FcmRoutingType.CHAT, "1234");
+        ResponseNotificationReadDto response = ResponseNotificationReadDto.success();
+
+        given(notificationReadService.markAsRead(nullable(Long.class), eq(FcmRoutingType.CHAT), eq(1234L)))
+                .willReturn(response);
+
+        ResultActions result = mockMvc.perform(
+                patch("/notifications/read")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpect(status().isOk())
+              .andExpect(jsonPath("$.success").value(true));
+    }
+
+    // =========================================================================
+    // AC-2: NOTICE — 대상 없어도 200 OK (멱등성)
+    // =========================================================================
+
+    @Test
+    @DisplayName("AC-2: 200 반환 — NOTICE 타입, 대상 UserNotification 없어도 성공")
+    void should_return_200_when_NOTICE_userNotification_not_found() throws Exception {
+        RequestNotificationReadDto request = new RequestNotificationReadDto(FcmRoutingType.NOTICE, "999");
+        ResponseNotificationReadDto response = ResponseNotificationReadDto.success();
+
+        given(notificationReadService.markAsRead(nullable(Long.class), eq(FcmRoutingType.NOTICE), eq(999L)))
+                .willReturn(response);
+
+        ResultActions result = mockMvc.perform(
+                patch("/notifications/read")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpect(status().isOk())
+              .andExpect(jsonPath("$.success").value(true));
+    }
+
+    // =========================================================================
+    // AC-3: targetId 파싱 실패 → 400
+    // =========================================================================
+
+    @Test
+    @DisplayName("AC-3: 400 반환 — targetId가 숫자가 아닌 문자열")
+    void should_return_400_when_targetId_is_not_numeric() throws Exception {
+        Map<String, String> body = Map.of("type", "NOTICE", "targetId", "abc");
+
+        ResultActions result = mockMvc.perform(
+                patch("/notifications/read")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)));
+
+        result.andExpect(status().isBadRequest());
+    }
+
+    // =========================================================================
+    // AC-5: CHAT — 방에 메시지 없어도 200 OK
+    // =========================================================================
+
+    @Test
+    @DisplayName("AC-5: 200 반환 — CHAT 타입, 방에 메시지 없어도 성공")
+    void should_return_200_when_CHAT_room_has_no_messages() throws Exception {
+        RequestNotificationReadDto request = new RequestNotificationReadDto(FcmRoutingType.CHAT, "1234");
+        ResponseNotificationReadDto response = ResponseNotificationReadDto.success();
+
+        given(notificationReadService.markAsRead(nullable(Long.class), eq(FcmRoutingType.CHAT), eq(1234L)))
+                .willReturn(response);
+
+        ResultActions result = mockMvc.perform(
+                patch("/notifications/read")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpect(status().isOk());
+    }
+
+    // =========================================================================
+    // AC-6: CHAT — 참여자 아닌 경우 → 서비스 예외 전파
+    // =========================================================================
+
+    @Test
+    @DisplayName("AC-6: 403 반환 — CHAT 타입, 채팅방 참여자 아님 (OPEN_CHAT_NOT_PARTICIPANT)")
+    void should_return_403_when_CHAT_user_is_not_participant() throws Exception {
+        RequestNotificationReadDto request = new RequestNotificationReadDto(FcmRoutingType.CHAT, "1234");
+
+        willThrow(new CustomException(ErrorCode.OPEN_CHAT_NOT_PARTICIPANT))
+                .given(notificationReadService).markAsRead(nullable(Long.class), eq(FcmRoutingType.CHAT), eq(1234L));
+
+        ResultActions result = mockMvc.perform(
+                patch("/notifications/read")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)));
+
+        result.andExpect(status().isForbidden());
+    }
+
+    // =========================================================================
+    // AC-7: 잘못된 type 값 → 400
+    // =========================================================================
+
+    @Test
+    @DisplayName("AC-7: 400 반환 — 잘못된 type 값 ('ROOMMATE')")
+    void should_return_400_when_type_is_invalid() throws Exception {
+        Map<String, String> body = Map.of("type", "ROOMMATE", "targetId", "123");
+
+        ResultActions result = mockMvc.perform(
+                patch("/notifications/read")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)));
+
+        result.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("AC-7: 400 반환 — type 필드 누락")
+    void should_return_400_when_type_is_null() throws Exception {
+        Map<String, String> body = Map.of("targetId", "123");
+
+        ResultActions result = mockMvc.perform(
+                patch("/notifications/read")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)));
+
+        result.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("400 반환 — targetId 필드 누락")
+    void should_return_400_when_targetId_is_blank() throws Exception {
+        Map<String, String> body = Map.of("type", "NOTICE");
+
+        ResultActions result = mockMvc.perform(
+                patch("/notifications/read")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)));
+
+        result.andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/example/appcenter_project/domain/notification/service/NotificationReadServiceTest.java
+++ b/src/test/java/com/example/appcenter_project/domain/notification/service/NotificationReadServiceTest.java
@@ -1,0 +1,185 @@
+package com.example.appcenter_project.domain.notification.service;
+
+import com.example.appcenter_project.domain.fcm.enums.FcmRoutingType;
+import com.example.appcenter_project.domain.notification.dto.response.ResponseNotificationReadDto;
+import com.example.appcenter_project.domain.notification.entity.Notification;
+import com.example.appcenter_project.domain.notification.entity.UserNotification;
+import com.example.appcenter_project.domain.notification.repository.UserNotificationQuerydslRepository;
+import com.example.appcenter_project.domain.openChat.service.OpenChatMessageService;
+import com.example.appcenter_project.domain.user.entity.User;
+import com.example.appcenter_project.global.exception.CustomException;
+import com.example.appcenter_project.global.exception.ErrorCode;
+import com.example.appcenter_project.shared.enums.ApiType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationReadServiceTest {
+
+    @Mock
+    private UserNotificationQuerydslRepository userNotificationQuerydslRepository;
+
+    @Mock
+    private OpenChatMessageService openChatMessageService;
+
+    @InjectMocks
+    private NotificationReadService notificationReadService;
+
+    private static final Long USER_ID = 1L;
+    private static final Long ANNOUNCEMENT_ID = 5678L;
+    private static final Long CHAT_ROOM_ID = 1234L;
+
+    // =========================================================================
+    // AC-1: NOTICE 타입 — isRead 업데이트
+    // =========================================================================
+
+    @Test
+    @DisplayName("AC-1: NOTICE 타입 요청 시 해당 UserNotification.isRead = true 로 변경")
+    void should_mark_userNotification_as_read_when_type_is_NOTICE() {
+        Notification notification = buildNotification(ANNOUNCEMENT_ID, ApiType.ANNOUNCEMENT);
+        UserNotification userNotification = UserNotification.of(buildUser(USER_ID), notification);
+
+        given(userNotificationQuerydslRepository.findByUserIdAndBoardIdAndApiType(
+                USER_ID, ANNOUNCEMENT_ID, ApiType.ANNOUNCEMENT))
+                .willReturn(List.of(userNotification));
+
+        ResponseNotificationReadDto result = notificationReadService.markAsRead(
+                USER_ID, FcmRoutingType.NOTICE, ANNOUNCEMENT_ID);
+
+        assertThat(userNotification.isRead()).isTrue();
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    @DisplayName("AC-1: NOTICE 타입 — 여러 개의 UserNotification이 있어도 모두 읽음 처리")
+    void should_mark_all_userNotifications_as_read_when_multiple_records_exist() {
+        Notification notification = buildNotification(ANNOUNCEMENT_ID, ApiType.ANNOUNCEMENT);
+        UserNotification un1 = UserNotification.of(buildUser(USER_ID), notification);
+        UserNotification un2 = UserNotification.of(buildUser(USER_ID), notification);
+
+        given(userNotificationQuerydslRepository.findByUserIdAndBoardIdAndApiType(
+                USER_ID, ANNOUNCEMENT_ID, ApiType.ANNOUNCEMENT))
+                .willReturn(List.of(un1, un2));
+
+        notificationReadService.markAsRead(USER_ID, FcmRoutingType.NOTICE, ANNOUNCEMENT_ID);
+
+        assertThat(un1.isRead()).isTrue();
+        assertThat(un2.isRead()).isTrue();
+    }
+
+    // =========================================================================
+    // AC-2: NOTICE 타입 — 대상 UserNotification 없어도 200 OK (멱등성)
+    // =========================================================================
+
+    @Test
+    @DisplayName("AC-2: NOTICE 타입 — 대상 UserNotification 없음 시 예외 없이 success=true 반환")
+    void should_return_success_when_NOTICE_userNotification_not_found() {
+        given(userNotificationQuerydslRepository.findByUserIdAndBoardIdAndApiType(
+                USER_ID, 999L, ApiType.ANNOUNCEMENT))
+                .willReturn(List.of());
+
+        ResponseNotificationReadDto result = notificationReadService.markAsRead(
+                USER_ID, FcmRoutingType.NOTICE, 999L);
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getMessage()).isEqualTo("성공적으로 읽음 처리되었습니다.");
+    }
+
+    // =========================================================================
+    // AC-4: CHAT 타입 — lastReadMessageId 업데이트
+    // =========================================================================
+
+    @Test
+    @DisplayName("AC-4: CHAT 타입 요청 시 OpenChatMessageService.markChatRoomAsRead 위임")
+    void should_delegate_to_openChatMessageService_when_type_is_CHAT() {
+        willDoNothing().given(openChatMessageService).markChatRoomAsRead(CHAT_ROOM_ID, USER_ID);
+
+        ResponseNotificationReadDto result = notificationReadService.markAsRead(
+                USER_ID, FcmRoutingType.CHAT, CHAT_ROOM_ID);
+
+        then(openChatMessageService).should(times(1)).markChatRoomAsRead(CHAT_ROOM_ID, USER_ID);
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    // =========================================================================
+    // AC-5: CHAT 타입 — 방에 메시지 없으면 성공 반환 (위임 후 서비스에서 처리)
+    // =========================================================================
+
+    @Test
+    @DisplayName("AC-5: CHAT 타입 — 방에 메시지 없어도 success=true 반환 (OpenChatMessageService 내부 처리)")
+    void should_return_success_when_CHAT_room_has_no_messages() {
+        willDoNothing().given(openChatMessageService).markChatRoomAsRead(CHAT_ROOM_ID, USER_ID);
+
+        ResponseNotificationReadDto result = notificationReadService.markAsRead(
+                USER_ID, FcmRoutingType.CHAT, CHAT_ROOM_ID);
+
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    // =========================================================================
+    // AC-6: CHAT 타입 — 참여자 아님 → 예외 전파
+    // =========================================================================
+
+    @Test
+    @DisplayName("AC-6: CHAT 타입 — 채팅방 참여자 아닌 경우 OPEN_CHAT_NOT_PARTICIPANT 예외 전파")
+    void should_propagate_exception_when_CHAT_user_is_not_participant() {
+        willThrow(new CustomException(ErrorCode.OPEN_CHAT_NOT_PARTICIPANT))
+                .given(openChatMessageService).markChatRoomAsRead(CHAT_ROOM_ID, USER_ID);
+
+        assertThatThrownBy(() -> notificationReadService.markAsRead(
+                USER_ID, FcmRoutingType.CHAT, CHAT_ROOM_ID))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.OPEN_CHAT_NOT_PARTICIPANT);
+    }
+
+    // =========================================================================
+    // 응답 메시지 검증
+    // =========================================================================
+
+    @Test
+    @DisplayName("성공 응답 — message 필드가 '성공적으로 읽음 처리되었습니다.' 고정값")
+    void should_return_fixed_success_message() {
+        willDoNothing().given(openChatMessageService).markChatRoomAsRead(CHAT_ROOM_ID, USER_ID);
+
+        ResponseNotificationReadDto result = notificationReadService.markAsRead(
+                USER_ID, FcmRoutingType.CHAT, CHAT_ROOM_ID);
+
+        assertThat(result.getMessage()).isEqualTo("성공적으로 읽음 처리되었습니다.");
+    }
+
+    // =========================================================================
+    // Helper
+    // =========================================================================
+
+    private Notification buildNotification(Long boardId, ApiType apiType) {
+        Notification notification = Notification.builder()
+                .boardId(boardId)
+                .title("테스트 공지")
+                .body("테스트 내용")
+                .apiType(apiType)
+                .build();
+        ReflectionTestUtils.setField(notification, "id", boardId);
+        return notification;
+    }
+
+    private User buildUser(Long userId) {
+        User user = User.createForTest(userId, "user-" + userId);
+        return user;
+    }
+}


### PR DESCRIPTION
## Summary

- `PATCH /notifications/read` 엔드포인트 추가
- `FcmRoutingType`(NOTICE/CHAT) 기반 분기 처리
  - NOTICE: `UserNotification` 읽음 상태(`isRead = true`) 업데이트
  - CHAT: `OpenChatRoom` 참여자 검증 후 `lastReadMessageId` 갱신
- 잘못된 enum 값 역직렬화 실패 시 400 처리 (`HttpMessageNotReadableException` 핸들러 추가)

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `NotificationReadService` | NOTICE/CHAT 분기 읽음 처리 서비스 |
| `RequestNotificationReadDto` | `FcmRoutingType` + `targetId` 파싱 |
| `ResponseNotificationReadDto` | `success(true)` 정적 팩토리 |
| `UserNotificationQuerydslRepository` | `findByUserIdAndBoardIdAndApiType` QueryDSL 구현 |
| `OpenChatMessageService` | `markChatRoomAsRead` 추가 |
| `NotificationController` | `PATCH /notifications/read` 엔드포인트 |
| `SecurityConfig` | 신규 엔드포인트 인증 규칙 추가 |
| `GlobalExceptionHandler` | enum 역직렬화 실패 400 처리 |

## Test plan

- [x] `NotificationReadServiceTest` — NOTICE/CHAT 분기, 예외 케이스 통과
- [x] `NotificationReadControllerTest` — 엔드포인트 통합 테스트 통과
- [x] 전체 회귀 테스트 통과 (BUILD SUCCESSFUL)

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)