### PR TITLE
Dain/fix/731 chat notification

### DIFF
--- a/src/main/java/com/example/appcenter_project/domain/openChat/controller/OpenChatRoomApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/controller/OpenChatRoomApiSpecification.java
@@ -4,13 +4,7 @@ import com.example.appcenter_project.domain.openChat.dto.request.RequestCreateDe
 import com.example.appcenter_project.domain.openChat.dto.request.RequestCreateOpenChatRoomDto;
 import com.example.appcenter_project.domain.openChat.dto.request.RequestCreatePersonalRoomDto;
 import com.example.appcenter_project.domain.openChat.dto.request.RequestUpdateNotificationModeDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponseChatRoomListDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponseDerivedRoomCreatedDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponseLeaveOpenChatRoomDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatParticipantListDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatRoomDetailDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponsePersonalRoomCreatedDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponseSimpleParticipantListDto;
+import com.example.appcenter_project.domain.openChat.dto.response.*;
 import com.example.appcenter_project.domain.openChat.enums.KickReason;
 import com.example.appcenter_project.domain.openChat.enums.OpenChatRoomTab;
 import com.example.appcenter_project.global.security.CustomUserDetails;
@@ -230,6 +224,26 @@ public interface OpenChatRoomApiSpecification {
             @RequestBody @Valid
             @Parameter(description = "알림 모드 (EVERY / BUNDLED / OFF)", required = true)
             RequestUpdateNotificationModeDto dto);
+
+    @Operation(
+            summary = "FCM 알림 모드 조회",
+            description = """
+                    해당 채팅방에서 내 현재 FCM 알림 모드를 조회합니다.
+
+                    **mode**: `EVERY`(즉시) / `BUNDLED`(묶음) / `OFF`(끄기)
+                    """,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(schema = @Schema(implementation = ResponseNotificationModeDto.class))),
+                    @ApiResponse(responseCode = "401", description = "인증 필요"),
+                    @ApiResponse(responseCode = "404", description = "채팅방 또는 참여 정보를 찾을 수 없음")
+            }
+    )
+    ResponseEntity<ResponseNotificationModeDto> getNotification(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable
+            @Parameter(description = "채팅방 ID", required = true, example = "1")
+            Long roomId);
 
     @Operation(
             summary = "채팅방 강제 삭제",

--- a/src/main/java/com/example/appcenter_project/domain/openChat/controller/OpenChatRoomController.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/controller/OpenChatRoomController.java
@@ -5,14 +5,7 @@ import com.example.appcenter_project.domain.openChat.dto.request.RequestCreateOp
 import com.example.appcenter_project.domain.openChat.dto.request.RequestCreatePersonalRoomDto;
 import com.example.appcenter_project.domain.openChat.dto.request.RequestUpdateNotificationModeDto;
 import com.example.appcenter_project.domain.openChat.dto.request.RequestUpdateOpenChatRoomDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponseChatRoomListDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponseDerivedRoomCreatedDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponseLeaveOpenChatRoomDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatParticipantListDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatRoomDetailDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponseOpenChatRoomDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponsePersonalRoomCreatedDto;
-import com.example.appcenter_project.domain.openChat.dto.response.ResponseSimpleParticipantListDto;
+import com.example.appcenter_project.domain.openChat.dto.response.*;
 import com.example.appcenter_project.domain.openChat.enums.KickReason;
 import com.example.appcenter_project.domain.openChat.enums.OpenChatRoomTab;
 import com.example.appcenter_project.domain.openChat.service.OpenChatRoomService;
@@ -96,6 +89,14 @@ public class OpenChatRoomController implements OpenChatRoomApiSpecification {
             @RequestBody @Valid RequestUpdateNotificationModeDto dto) {
         openChatRoomService.updateNotificationMode(user.getId(), roomId, dto.getMode());
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{roomId}/participants/me/notification")
+    public ResponseEntity<ResponseNotificationModeDto> getNotification(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long roomId) {
+        ResponseNotificationModeDto result = openChatRoomService.getNotificationMode(user.getId(), roomId);
+        return ResponseEntity.ok(result);
     }
 
     @DeleteMapping("/{roomId}/participants/{targetUserId}")

--- a/src/main/java/com/example/appcenter_project/domain/openChat/dto/response/ResponseNotificationModeDto.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/dto/response/ResponseNotificationModeDto.java
@@ -1,0 +1,17 @@
+package com.example.appcenter_project.domain.openChat.dto.response;
+
+import com.example.appcenter_project.domain.openChat.enums.ChatNotificationMode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ResponseNotificationModeDto {
+
+    private ChatNotificationMode mode;
+
+    public static ResponseNotificationModeDto of(ChatNotificationMode mode) {
+        return new ResponseNotificationModeDto(mode);
+    }
+}

--- a/src/main/java/com/example/appcenter_project/domain/openChat/entity/OpenChatParticipant.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/entity/OpenChatParticipant.java
@@ -57,6 +57,16 @@ public class OpenChatParticipant {
         return participant;
     }
 
+    public static OpenChatParticipant create(Long roomId, Long userId, LocalDateTime joinedAt, ChatNotificationMode mode) {
+        OpenChatParticipant participant = new OpenChatParticipant();
+        participant.roomId = roomId;
+        participant.userId = userId;
+        participant.joinedAt = joinedAt;
+        participant.notificationMode = mode;
+        participant.isHost = false;
+        return participant;
+    }
+
     public void grantHost() {
         this.isHost = true;
     }
@@ -72,4 +82,5 @@ public class OpenChatParticipant {
     public void updateNotificationMode(ChatNotificationMode mode) {
         this.notificationMode = mode;
     }
+
 }

--- a/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatRoomQuerydslRepositoryImpl.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/repository/OpenChatRoomQuerydslRepositoryImpl.java
@@ -10,9 +10,11 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public class OpenChatRoomQuerydslRepositoryImpl implements OpenChatRoomQuerydslRepository {
 
     private final JPAQueryFactory queryFactory;

--- a/src/main/java/com/example/appcenter_project/domain/openChat/service/OpenChatDormOfficialRoomService.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/service/OpenChatDormOfficialRoomService.java
@@ -6,6 +6,7 @@ import com.example.appcenter_project.domain.openChat.entity.OpenChatParticipant;
 import com.example.appcenter_project.domain.openChat.entity.OpenChatRoom;
 import com.example.appcenter_project.domain.openChat.repository.OpenChatParticipantRepository;
 import com.example.appcenter_project.domain.openChat.repository.OpenChatRoomRepository;
+import com.example.appcenter_project.domain.openChat.enums.ChatNotificationMode;
 import com.example.appcenter_project.domain.user.entity.User;
 import com.example.appcenter_project.domain.user.enums.DormType;
 import com.example.appcenter_project.domain.user.repository.UserRepository;
@@ -41,7 +42,8 @@ public class OpenChatDormOfficialRoomService {
 
         List<User> users = userRepository.findAllByDormType(dormType);
         List<OpenChatParticipant> participants = users.stream()
-                .map(u -> OpenChatParticipant.create(savedRoom.getId(), u.getId(), LocalDateTime.now()))
+                .map(u -> OpenChatParticipant.create(savedRoom.getId(), u.getId(),
+                        LocalDateTime.now(), ChatNotificationMode.BUNDLED))
                 .toList();
         openChatParticipantRepository.saveAll(participants);
 
@@ -78,7 +80,7 @@ public class OpenChatDormOfficialRoomService {
             openChatRoomRepository.findByTargetDorm(newDorm).ifPresent(room -> {
                 if (!openChatParticipantRepository.existsByRoomIdAndUserId(room.getId(), userId)) {
                     openChatParticipantRepository.save(
-                            OpenChatParticipant.create(room.getId(), userId, LocalDateTime.now())
+                            OpenChatParticipant.create(room.getId(), userId, LocalDateTime.now(), ChatNotificationMode.BUNDLED)
                     );
                 }
             });

--- a/src/main/java/com/example/appcenter_project/domain/openChat/service/OpenChatRoomService.java
+++ b/src/main/java/com/example/appcenter_project/domain/openChat/service/OpenChatRoomService.java
@@ -25,6 +25,7 @@ import com.example.appcenter_project.domain.openChat.repository.OpenChatMessageR
 import com.example.appcenter_project.domain.openChat.repository.OpenChatParticipantRepository;
 import com.example.appcenter_project.domain.openChat.repository.OpenChatRoomQuerydslRepository;
 import com.example.appcenter_project.domain.openChat.repository.OpenChatRoomRepository;
+import com.example.appcenter_project.domain.openChat.dto.response.ResponseNotificationModeDto;
 import org.springframework.beans.factory.annotation.Qualifier;
 import com.example.appcenter_project.domain.block.service.BlockService;
 import com.example.appcenter_project.domain.roommate.entity.RoommateChattingChat;
@@ -320,7 +321,11 @@ public class OpenChatRoomService {
             throw new CustomException(ErrorCode.OPEN_CHAT_ROOM_FULL);
         }
 
-        openChatParticipantRepository.save(OpenChatParticipant.create(roomId, userId, LocalDateTime.now()));
+        ChatNotificationMode defaultMode = (room.isOfficial() && room.getTargetDorm() != null)
+                ? ChatNotificationMode.BUNDLED
+                : ChatNotificationMode.EVERY;
+        openChatParticipantRepository.save(
+                OpenChatParticipant.create(roomId, userId, LocalDateTime.now(), defaultMode));
         openChatMessageService.sendSystemMessage(roomId, user.getName() + "님이 입장했습니다.");
 
         return toDetailDto(room, roomId);
@@ -424,6 +429,14 @@ public class OpenChatRoomService {
                 .findByRoomIdAndUserId(roomId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.OPEN_CHAT_PARTICIPANT_NOT_FOUND));
         participant.updateNotificationMode(mode);
+    }
+
+    @Transactional(readOnly = true)
+    public ResponseNotificationModeDto getNotificationMode(Long userId, Long roomId) {
+        OpenChatParticipant participant = openChatParticipantRepository
+                .findByRoomIdAndUserId(roomId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.OPEN_CHAT_PARTICIPANT_NOT_FOUND));
+        return ResponseNotificationModeDto.of(participant.getNotificationMode());
     }
 
     @Transactional

--- a/src/test/java/com/example/appcenter_project/domain/openChat/controller/OpenChatNotificationControllerTest.java
+++ b/src/test/java/com/example/appcenter_project/domain/openChat/controller/OpenChatNotificationControllerTest.java
@@ -1,0 +1,66 @@
+package com.example.appcenter_project.domain.openChat.controller;
+
+import com.example.appcenter_project.domain.openChat.dto.response.ResponseNotificationModeDto;
+import com.example.appcenter_project.domain.openChat.enums.ChatNotificationMode;
+import com.example.appcenter_project.domain.openChat.service.OpenChatRoomService;
+import com.example.appcenter_project.domain.user.entity.User;
+import com.example.appcenter_project.global.exception.SlackErrorNotifier;
+import com.example.appcenter_project.global.security.CustomUserDetails;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(OpenChatRoomController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class OpenChatNotificationControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockBean OpenChatRoomService openChatRoomService;
+    @MockBean SlackErrorNotifier slackErrorNotifier;
+    @MockBean JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.createForTest(7L, "테스트유저");
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, null, List.of()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("200 + mode 반환 — GET 알림 모드 조회")
+    void should_return_200_with_mode_when_get_notification() throws Exception {
+        given(openChatRoomService.getNotificationMode(anyLong(), eq(1L)))
+                .willReturn(ResponseNotificationModeDto.of(ChatNotificationMode.BUNDLED));
+
+        mockMvc.perform(get("/open-chat-rooms/1/participants/me/notification")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mode").value("BUNDLED"));
+    }
+}

--- a/src/test/java/com/example/appcenter_project/domain/openChat/controller/OpenChatNotificationControllerTest.java
+++ b/src/test/java/com/example/appcenter_project/domain/openChat/controller/OpenChatNotificationControllerTest.java
@@ -14,11 +14,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -35,9 +35,10 @@ class OpenChatNotificationControllerTest {
     @Autowired MockMvc mockMvc;
     @Autowired ObjectMapper objectMapper;
 
-    @MockBean OpenChatRoomService openChatRoomService;
-    @MockBean SlackErrorNotifier slackErrorNotifier;
-    @MockBean JpaMetamodelMappingContext jpaMetamodelMappingContext;
+    @MockitoBean
+    OpenChatRoomService openChatRoomService;
+    @MockitoBean SlackErrorNotifier slackErrorNotifier;
+    @MockitoBean JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/example/appcenter_project/domain/openChat/entity/OpenChatParticipantNotificationTest.java
+++ b/src/test/java/com/example/appcenter_project/domain/openChat/entity/OpenChatParticipantNotificationTest.java
@@ -1,0 +1,21 @@
+package com.example.appcenter_project.domain.openChat.entity;
+
+import com.example.appcenter_project.domain.openChat.enums.ChatNotificationMode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenChatParticipantNotificationTest {
+
+    @Test
+    @DisplayName("create(roomId, userId, joinedAt, mode) — 지정한 알림 모드로 생성")
+    void factory_sets_notification_mode() {
+        OpenChatParticipant p = OpenChatParticipant.create(
+                1L, 10L, LocalDateTime.now(), ChatNotificationMode.BUNDLED);
+
+        assertThat(p.getNotificationMode()).isEqualTo(ChatNotificationMode.BUNDLED);
+    }
+}

--- a/src/test/java/com/example/appcenter_project/domain/openChat/service/OpenChatDormOfficialRoomServiceTest.java
+++ b/src/test/java/com/example/appcenter_project/domain/openChat/service/OpenChatDormOfficialRoomServiceTest.java
@@ -3,6 +3,7 @@ package com.example.appcenter_project.domain.openChat.service;
 import com.example.appcenter_project.domain.openChat.dto.request.RequestCreateDormOfficialRoomDto;
 import com.example.appcenter_project.domain.openChat.entity.OpenChatParticipant;
 import com.example.appcenter_project.domain.openChat.entity.OpenChatRoom;
+import com.example.appcenter_project.domain.openChat.enums.ChatNotificationMode;
 import com.example.appcenter_project.domain.openChat.fixture.OpenChatDormOfficialRoomFixture;
 import com.example.appcenter_project.domain.openChat.repository.OpenChatParticipantRepository;
 import com.example.appcenter_project.domain.openChat.repository.OpenChatRoomRepository;
@@ -330,5 +331,37 @@ class OpenChatDormOfficialRoomServiceTest {
 
         // then
         then(openChatParticipantRepository).should(never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("공식방 참여자 기본 알림 = BUNDLED — 벌크 생성 시 전원 1시간 묶음")
+    void should_create_participants_with_bundled_when_official_room() {
+        RequestCreateDormOfficialRoomDto request = OpenChatDormOfficialRoomFixture.createRequest();
+        List<User> users = OpenChatDormOfficialRoomFixture.createUsersWithDorm(DormType.DORM_1, 3);
+        OpenChatRoom savedRoom = OpenChatDormOfficialRoomFixture.createDormOfficialRoom(DormType.DORM_1);
+        given(openChatRoomRepository.findByTargetDorm(DormType.DORM_1)).willReturn(Optional.empty());
+        given(userRepository.findAllByDormType(DormType.DORM_1)).willReturn(users);
+        given(openChatRoomRepository.save(any())).willReturn(savedRoom);
+
+        openChatDormOfficialRoomService.createDormOfficialRoom(1L, request);
+
+        then(openChatParticipantRepository).should().saveAll(argThat(list ->
+                ((List<OpenChatParticipant>) list).stream()
+                        .allMatch(p -> p.getNotificationMode() == ChatNotificationMode.BUNDLED)
+        ));
+    }
+
+    @Test
+    @DisplayName("재배정 재입장 참여자 기본 알림 = BUNDLED")
+    void should_create_participant_with_bundled_on_reassign() {
+        OpenChatRoom newRoom = OpenChatDormOfficialRoomFixture.createDormOfficialRoom(DormType.DORM_1);
+        given(openChatRoomRepository.findByTargetDorm(DormType.DORM_1)).willReturn(Optional.of(newRoom));
+        given(openChatParticipantRepository.existsByRoomIdAndUserId(any(), eq(10L))).willReturn(false);
+        ArgumentCaptor<OpenChatParticipant> captor = ArgumentCaptor.forClass(OpenChatParticipant.class);
+
+        openChatDormOfficialRoomService.reassignDormRoom(10L, DormType.NONE, DormType.DORM_1);
+
+        then(openChatParticipantRepository).should().save(captor.capture());
+        assertThat(captor.getValue().getNotificationMode()).isEqualTo(ChatNotificationMode.BUNDLED);
     }
 }

--- a/src/test/java/com/example/appcenter_project/domain/openChat/service/OpenChatNotificationDefaultServiceTest.java
+++ b/src/test/java/com/example/appcenter_project/domain/openChat/service/OpenChatNotificationDefaultServiceTest.java
@@ -1,0 +1,95 @@
+package com.example.appcenter_project.domain.openChat.service;
+
+import com.example.appcenter_project.domain.openChat.dto.response.ResponseNotificationModeDto;
+import com.example.appcenter_project.domain.openChat.entity.OpenChatParticipant;
+import com.example.appcenter_project.domain.openChat.entity.OpenChatRoom;
+import com.example.appcenter_project.domain.openChat.enums.ChatNotificationMode;
+import com.example.appcenter_project.domain.openChat.repository.OpenChatParticipantRepository;
+import com.example.appcenter_project.domain.openChat.repository.OpenChatRoomRepository;
+import com.example.appcenter_project.domain.user.entity.User;
+import com.example.appcenter_project.domain.user.enums.DormType;
+import com.example.appcenter_project.domain.user.repository.UserRepository;
+import com.example.appcenter_project.global.exception.CustomException;
+import com.example.appcenter_project.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OpenChatNotificationDefaultServiceTest {
+
+    @Mock OpenChatRoomRepository openChatRoomRepository;
+    @Mock OpenChatParticipantRepository openChatParticipantRepository;
+    @Mock UserRepository userRepository;
+    @Mock OpenChatMessageService openChatMessageService;
+
+    @InjectMocks OpenChatRoomService openChatRoomService;
+
+    private static final Long USER_ID = 10L;
+
+    @Test
+    @DisplayName("joinRoom — 공식 기숙사방 입장 시 기본 알림 = BUNDLED")
+    void official_room_join_defaults_bundled() {
+        OpenChatRoom room = OpenChatRoom.createDormOfficialForTest(1L, "1기숙사 공식방", DormType.DORM_1);
+        User user = User.createForTest(USER_ID, "tester");
+        given(openChatRoomRepository.findByIdWithLock(1L)).willReturn(Optional.of(room));
+        given(openChatParticipantRepository.existsByRoomIdAndUserId(1L, USER_ID)).willReturn(false);
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+        given(openChatParticipantRepository.countByRoomId(1L)).willReturn(0L);
+        ArgumentCaptor<OpenChatParticipant> captor = ArgumentCaptor.forClass(OpenChatParticipant.class);
+
+        openChatRoomService.joinRoom(USER_ID, 1L, null);
+
+        then(openChatParticipantRepository).should().save(captor.capture());
+        assertThat(captor.getValue().getNotificationMode()).isEqualTo(ChatNotificationMode.BUNDLED);
+    }
+
+    @Test
+    @DisplayName("joinRoom — 일반 방 입장 시 기본 알림 = EVERY")
+    void regular_room_join_defaults_every() {
+        OpenChatRoom room = OpenChatRoom.createForTest(2L, "일반방");
+        User user = User.createForTest(USER_ID, "tester");
+        given(openChatRoomRepository.findByIdWithLock(2L)).willReturn(Optional.of(room));
+        given(openChatParticipantRepository.existsByRoomIdAndUserId(2L, USER_ID)).willReturn(false);
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+        given(openChatParticipantRepository.countByRoomId(2L)).willReturn(0L);
+        ArgumentCaptor<OpenChatParticipant> captor = ArgumentCaptor.forClass(OpenChatParticipant.class);
+
+        openChatRoomService.joinRoom(USER_ID, 2L, null);
+
+        then(openChatParticipantRepository).should().save(captor.capture());
+        assertThat(captor.getValue().getNotificationMode()).isEqualTo(ChatNotificationMode.EVERY);
+    }
+
+    @Test
+    @DisplayName("getNotificationMode — 참여자의 현재 알림 모드 반환")
+    void getNotificationMode_returns_participant_mode() {
+        OpenChatParticipant p = OpenChatParticipant.create(1L, USER_ID, LocalDateTime.now(), ChatNotificationMode.BUNDLED);
+        given(openChatParticipantRepository.findByRoomIdAndUserId(1L, USER_ID)).willReturn(Optional.of(p));
+
+        ResponseNotificationModeDto result = openChatRoomService.getNotificationMode(USER_ID, 1L);
+
+        assertThat(result.getMode()).isEqualTo(ChatNotificationMode.BUNDLED);
+    }
+
+    @Test
+    @DisplayName("getNotificationMode — 비참여자면 OPEN_CHAT_PARTICIPANT_NOT_FOUND")
+    void getNotificationMode_throws_when_not_participant() {
+        given(openChatParticipantRepository.findByRoomIdAndUserId(1L, USER_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> openChatRoomService.getNotificationMode(USER_ID, 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.OPEN_CHAT_PARTICIPANT_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
방 유형별 기본 알림값과 사용자 설정 변경은 정상 저장되고 실제로 적용되어야 한다

 흐름
1. B가 기본 참여 오픈채팅방 알림 설정에 들어간다.
2. 기본값이 1시간 묶음 알림인지 확인한다.
3. 일반 파생 톡방 또는 다른 채팅방에 들어간다.
4. 기본값이 즉시 알림인지 확인한다.
5. 각 방의 알림을 다른 값으로 바꾼다.
6. 다시 들어가도 바뀐 값이 유지되는지 확인한다.
7. 실제 메시지를 보내 알림 수신도 변경한 값대로 동작하는지 확인한다.
기대 결과:기본 오픈채팅방은 1시간 묶음 알림, 그 외는 즉시 알림이어야 하고 설정 변경도 정상 저장/적용되어야 한다.
기대효과:방 중요도에 맞는 알림 경험을 제공할 수 있다.